### PR TITLE
side-by-side original and translation

### DIFF
--- a/lib/element.py
+++ b/lib/element.py
@@ -161,7 +161,30 @@ class PageElement(Element):
                 xml_escape(pattern), lambda _: get_string(reserve),
                 translation)
         translation = self._polish_translation(translation)
-        new_element = etree.XML('<{0} xmlns="{1}">{2}</{0}>'.format(
+
+        if position == 'sidebyside':
+            new_element = etree.Element(get_name(self.element), xmlns=ns['x'])
+            # Create table structure
+            table = etree.SubElement(new_element, 'table')
+            tr = etree.SubElement(table, 'tr')
+
+            # Original text on the left column
+            td_original = etree.SubElement(tr, 'td')
+            td_original.set('width', '45%')
+            td_orig_elem = td_original.append(self.element_copy)
+
+            # Middle column
+            td_middle = etree.SubElement(tr, 'td')
+            td_middle.set('padding', '10px')
+            # looks awful, but I couldn't find better way to keep the gap:
+            td_middle.text = xml_escape('&#xA0;&#xA0;&#xA0;&#xA0;')
+
+            # Translation on the right column
+            td_translation = etree.SubElement(tr, 'td')
+            td_translation.set('width', '45%')
+            td_translation.text = trim(translation)
+        else:
+            new_element = etree.XML('<{0} xmlns="{1}">{2}</{0}>'.format(
             get_name(self.element), ns['x'], trim(translation)))
         # Preserve all attributes from the original element.
         for name, value in self.element.items():
@@ -180,7 +203,7 @@ class PageElement(Element):
             self.element.addprevious(new_element)
         else:
             self.element.addnext(new_element)
-        if position == 'only':
+        if position == 'only' or position == 'sidebyside':
             self.delete()
         return new_element
 

--- a/setting.py
+++ b/setting.py
@@ -693,18 +693,21 @@ class TranslationSetting(QDialog):
         after_original.setChecked(True)
         before_original = QRadioButton(_('Add before original'))
         delete_original = QRadioButton(_('Add without original'))
+        side_by_side = QRadioButton(_('Side-by-side'))
         position_layout.addWidget(after_original)
         position_layout.addWidget(before_original)
         position_layout.addWidget(delete_original)
+        position_layout.addWidget(side_by_side)
         position_layout.addStretch(1)
         layout.addWidget(position_group)
 
-        position_map = dict(enumerate(['after', 'before', 'only']))
+        position_map = dict(enumerate(['after', 'before', 'only', 'sidebyside']))
         position_rmap = dict((v, k) for k, v in position_map.items())
         position_btn_group = QButtonGroup(position_group)
         position_btn_group.addButton(after_original, 0)
         position_btn_group.addButton(before_original, 1)
         position_btn_group.addButton(delete_original, 2)
+        position_btn_group.addButton(side_by_side, 3)
 
         position_btn_group.button(position_rmap.get(
             self.config.get('translation_position'))).setChecked(True)


### PR DESCRIPTION
Added side-by-side original/translation option.

(Seen this request on forum, and actually personally for me it's more convenient to see text in two columns, much easier to refer to original, if translation isn't clear enough)

![Screenshot 2024-03-07 at 21 07 19](https://github.com/bookfere/Ebook-Translator-Calibre-Plugin/assets/61196357/81808709-ecf5-4dc2-a66a-ca84b6aed7b2)
![Screenshot 2024-03-07 at 21 08 11](https://github.com/bookfere/Ebook-Translator-Calibre-Plugin/assets/61196357/9df8c116-23fb-4f0d-9527-c01d9ec46d8c)
