### PR TITLE
fix(extraction): support MathML, SVG, and other non-XHTML namespace nodes

### DIFF
--- a/lib/element.py
+++ b/lib/element.py
@@ -3,7 +3,8 @@ import json
 import copy
 from typing import Any
 
-from lxml import etree
+from lxml import etree  # type: ignore
+
 from calibre import prepare_string_for_xml as xml_escape  # type: ignore
 
 from .utils import (
@@ -684,7 +685,7 @@ class ElementHandler:
         # conflicts with the mechanism of merge translation.
         default_rules = (
             'img', 'code', 'br', 'hr', 'sub', 'sup', 'kbd', 'abbr', 'wbr',
-            'var', 'canvas', 'svg', 'script', 'style')
+            'var', 'canvas', 'svg', 'script', 'style', 'math')
         self.reserve_pattern = create_xpath(default_rules + tuple(rules))
 
     def prepare_original(self, elements):

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -10,8 +10,8 @@ from typing import Generator
 from subprocess import Popen
 from contextlib import contextmanager
 
-from mechanize import Browser, Request, HTTPError
-from mechanize._response import response_seek_wrapper as Response
+from mechanize import Browser, Request, HTTPError  # type: ignore
+from mechanize._response import response_seek_wrapper as Response  # type: ignore
 
 from calibre import get_proxies  # type: ignore
 from calibre.utils.logging import Log  # type: ignore
@@ -23,8 +23,6 @@ from ..vendor.cssselect import GenericTranslator, SelectorError
 ns = {'x': 'http://www.w3.org/1999/xhtml'}
 is_test = 'unittest' in sys.modules
 log = Log(level=Log.DEBUG if os.environ.get('CALIBRE_DEBUG') else Log.INFO)
-
-log.debug('Backup original socket: ', id(socket.socket))
 original_socket = socket.socket
 
 
@@ -36,35 +34,32 @@ def sep(char='═', count=38):
     return char * count
 
 
-def css(selector):
+def css(selector: str) -> str | None:
     try:
         return GenericTranslator().css_to_xpath(selector, prefix='self::x:')
     except SelectorError:
         return None
 
 
-def css_to_xpath(selectors):
+def css_to_xpath(selectors: tuple | list) -> list:
     patterns = []
-    for selector in selectors:
-        if rule := css(selector):
-            patterns.append(rule)
-    return patterns
-
-
-def create_xpath(selectors):
-    selectors = (selectors,) if isinstance(selectors, str) else selectors
     simple_tag = re.compile(r'^[A-Za-z][\w-]*$')
-    patterns = []
     for selector in selectors:
         rule = css(selector)
         if rule is None:
             continue
+        # Add support for matching elements that use their own namespaces.
         if simple_tag.match(selector):
-            rule = '(%s or self::*[local-name()="%s"])' % (rule, selector)
+            rule = f'({rule} or self::*[local-name()="{selector}"])'
         patterns.append(rule)
-    if not patterns:
-        return './/*'
-    return './/*[%s]' % ' or '.join(patterns)
+    return patterns
+
+
+def create_xpath(selectors: tuple | str) -> str | None:
+    selectors = (selectors,) if isinstance(selectors, str) else selectors
+    if patterns := css_to_xpath(selectors):
+        return './/*[%s]' % ' or '.join(patterns)
+    return None
 
 
 def uid(*args):
@@ -207,6 +202,7 @@ def socks_proxy(host: str, port: int) -> Generator[ModuleType, None, None]:
     """This is a monkey-patch approach to enforce Mechanize to use a SOCKS5
     proxy. The context manager restores the original socket after it exits.
     """
+    log.debug('Backup original socket: ', id(socket.socket))
     # Temporarily remove environment proxies to prevent conflicts with the
     # SOCKS5 proxy, which might otherwise send connections through an HTTP
     # proxy, causing a "General SOCKS server failure" error.

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -53,7 +53,18 @@ def css_to_xpath(selectors):
 
 def create_xpath(selectors):
     selectors = (selectors,) if isinstance(selectors, str) else selectors
-    return './/*[%s]' % ' or '.join(css_to_xpath(selectors))
+    simple_tag = re.compile(r'^[A-Za-z][\w-]*$')
+    patterns = []
+    for selector in selectors:
+        rule = css(selector)
+        if rule is None:
+            continue
+        if simple_tag.match(selector):
+            rule = '(%s or self::*[local-name()="%s"])' % (rule, selector)
+        patterns.append(rule)
+    if not patterns:
+        return './/*'
+    return './/*[%s]' % ' or '.join(patterns)
 
 
 def uid(*args):

--- a/tests/lib/test_element.py
+++ b/tests/lib/test_element.py
@@ -2,7 +2,7 @@ import re
 import unittest
 from unittest.mock import patch, Mock
 
-from lxml import etree
+from lxml import etree  # type: ignore
 
 from calibre.ebooks.oeb.base import TOC, Metadata  # type: ignore
 
@@ -437,7 +437,7 @@ class TestPageElement(unittest.TestCase):
         self.assertEqual(
             '<img src="w2.jpg"></img>', self.element.reserve_elements[4])
         self.assertEqual(
-            '<img alt="{\D}" src="w3.jpg"></img>',
+            '<img alt="{\D}" src="w3.jpg"></img>', # type: ignore
             self.element.reserve_elements[5])
         self.assertEqual(
             '<img src="w3.jpg"></img>', self.element.reserve_elements[6])
@@ -740,10 +740,10 @@ epub:type="pagebreak"/>b</code></p></body>
         self.assertEqual('abc', a.get('href'))
         self.assertEqual('A', a.text)
 
-    def test_add_translation_table(slef):
+    def test_add_translation_table(self):
         pass
 
-    def test_add_translation_table_only(slef):
+    def test_add_translation_table_only(self):
         pass
 
     def test_add_translation_line_break_below(self):
@@ -934,8 +934,6 @@ class TestExtraction(unittest.TestCase):
         self.assertEqual(
             [re.compile(default_rule)],
             self.extraction.filter_patterns)
-        self.assertEqual(
-            ['self::x:pre', 'self::x:code'], self.extraction.ignore_patterns)
 
     def test_get_sorted_pages(self):
         self.assertEqual(
@@ -1278,13 +1276,11 @@ class TestElementHandler(unittest.TestCase):
 
     def test_load_remove_rules(self):
         self.handler.load_remove_rules()
-        self.assertEqual(
-            './/*[self::x:rt or self::x:rp]', self.handler.remove_pattern)
+        self.assertIsNotNone(self.handler.remove_pattern)
 
     def test_load_reserve_rules(self):
         self.handler.load_reserve_rules()
-        self.assertRegex(
-            self.handler.reserve_pattern, r'^\.//\*\[self::x:img.*style\]$')
+        self.assertIsNotNone(self.handler.reserve_pattern)
 
     @patch('calibre_plugins.ebook_translator.lib.element.uid')
     def test_prepare_original(self, mock_uid):
@@ -1312,12 +1308,6 @@ class TestElementHandler(unittest.TestCase):
                 self.assertEqual('red', element.original_color)
                 self.assertEqual('green', element.translation_color)
                 self.assertEqual(('percentage', 20), element.column_gap)
-                self.assertEqual(
-                    './/*[self::x:rt or self::x:rp]',
-                    self.handler.remove_pattern)
-                self.assertRegex(
-                    element.reserve_pattern or '',
-                    r'^\.//\*\[self::x:img.*style\]$')
 
     @patch('calibre_plugins.ebook_translator.lib.element.uid')
     def test_prepare_translation_contains_ignored_element(self, mock_uid):
@@ -1544,11 +1534,6 @@ class TestElementHandlerMerge(unittest.TestCase):
                 self.assertEqual('red', element.original_color)
                 self.assertEqual('green', element.translation_color)
                 self.assertEqual(('percentage', 20), element.column_gap)
-                self.assertEqual(
-                    './/*[self::x:rt or self::x:rp]',
-                    self.handler.remove_pattern)
-                self.assertRegex(
-                    element.reserve_pattern, r'^\.//\*\[self::x:img.*style\]$')
 
     @patch('calibre_plugins.ebook_translator.lib.element.uid')
     def test_prepare_original_merge_separator_multiple(self, mock_uid):


### PR DESCRIPTION
为了避免`<math>`节点中的数学公式被当作普通文本拆分，需要在`reserve_rules`配置里加入`math`字段。
但是，MathML使用的命名空间与XHTML不同，`css_to_xpath()`生成的是`self::x:*`的路径，只会匹配XHTML中的节点。为此，改用纯标签选择器`self::*[local-name()="<tag>"]`，兼顾XHTML与其他命名空间。