### PR TITLE
feat: separate metadata/TOC translation architecture with Advanced Mode UI

### DIFF
--- a/advanced.py
+++ b/advanced.py
@@ -6,7 +6,7 @@ from qt.core import (  # type: ignore
     QPlainTextEdit, QPushButton, QSplitter, QLabel, QThread, QLineEdit,
     QGridLayout, QProgressBar, pyqtSignal, pyqtSlot, QPixmap, QEvent,
     QStackedWidget, QSpacerItem, QTabWidget, QCheckBox,
-    QComboBox, QSizePolicy)
+    QComboBox, QSizePolicy, QTextCursor)
 from calibre.constants import __version__  # type: ignore
 from calibre.gui2 import I  # type: ignore
 from calibre.utils.localization import _  # type: ignore
@@ -17,9 +17,10 @@ from .lib.config import get_config
 from .lib.encodings import encoding_list
 from .lib.cache import Paragraph, get_cache
 from .lib.translation import get_engine_class, get_translator, get_translation
-from .lib.element import get_element_handler
+from .lib.element import get_element_handler, MetadataElement, TocElement, PageElement
 from .lib.conversion import extract_item, extra_formats
 from .engines.openai import ChatgptTranslate, ChatgptBatchTranslate
+from .engines.anthropic import ClaudeTranslate
 from .engines.custom import CustomTranslate
 from .components import (
     EngineList, Footer, SourceLang, TargetLang, InputFormat, OutputFormat,
@@ -63,7 +64,7 @@ class PreparationWorker(QObject):
 
     def __init__(self, engine_class, ebook):
         QObject.__init__(self)
-        self.engine_class = engine_class
+        self.current_engine = engine_class
         self.ebook = ebook
 
         self.on_working = False
@@ -88,22 +89,19 @@ class PreparationWorker(QObject):
         self.on_working = True
         input_path = self.ebook.get_input_path()
         element_handler = get_element_handler(
-            self.engine_class.placeholder, self.engine_class.separator,
+            self.current_engine.placeholder, self.current_engine.separator,
             self.ebook.target_direction)
-        merge_length = str(element_handler.get_merge_length())
-        encoding = ''
-        if self.ebook.encoding.lower() != 'utf-8':
-            encoding = self.ebook.encoding.lower()
-        cache_id = uid(
-            input_path + self.engine_class.name + self.ebook.target_lang
-            + merge_length + encoding)
+        from .lib.utils import get_cache_id
+        merge_length = element_handler.get_merge_length()
+        cache_id = get_cache_id(input_path, self.current_engine.name, self.ebook.target_lang,
+                                merge_length, self.ebook.encoding)
         cache = get_cache(cache_id)
 
         if cache.is_fresh() or not cache.is_persistence():
             self.progress_detail.emit(
                 'Start processing the ebook: %s' % self.ebook.title)
             cache.set_info('title', self.ebook.title)
-            cache.set_info('engine_name', self.engine_class.name)
+            cache.set_info('engine_name', self.current_engine.name)
             cache.set_info('target_lang', self.ebook.target_lang)
             cache.set_info('merge_length', merge_length)
             cache.set_info('plugin_version', EbookTranslator.__version__)
@@ -134,7 +132,39 @@ class PreparationWorker(QObject):
                 return
             # --------------------------
             self.progress_message.emit(_('Filtering ebook content...'))
-            original_group = element_handler.prepare_original(elements)
+
+            # Separate metadata, TOC, and content (same logic as convert_book)
+            from .lib.utils import uid
+            metadata_elements = [e for e in elements if isinstance(e, MetadataElement)]
+            toc_elements = [e for e in elements if isinstance(e, TocElement)]
+            page_elements = [e for e in elements if isinstance(e, PageElement)]
+
+            # Store metadata originals directly (not merged)
+            # Only store ENABLED metadata fields (ignored ones don't appear in UI)
+            metadata_originals = []
+            for eid, metadata_elem in enumerate(metadata_elements):
+                if metadata_elem.ignored:
+                    continue  # Skip disabled metadata fields
+
+                original_value = metadata_elem.get_content()
+                item_id = -(eid + 1)  # Use negative IDs to avoid conflicts
+                md5 = uid('metadata_%s%s' % (eid, original_value))
+                metadata_originals.append((item_id, md5, original_value, original_value,
+                                          False, None, 'content.opf'))
+
+            # Store TOC as single merged entry
+            toc_originals = []
+            if toc_elements:
+                toc_texts = [toc.get_content() for toc in toc_elements if not toc.ignored]
+                if toc_texts:
+                    merged_toc = '\n\n'.join(toc_texts)
+                    toc_id = 'toc_merged'
+                    md5 = uid('toc_%s' % merged_toc)
+                    toc_originals.append((toc_id, md5, merged_toc, merged_toc, False, None, 'toc.ncx'))
+
+            # Prepare content/pages only (may be merged)
+            content_originals = element_handler.prepare_original(page_elements)
+
             self.progress.emit(80)
             c = time.time()
             self.progress_detail.emit('filtering timing: %s' % (c - b))
@@ -143,7 +173,14 @@ class PreparationWorker(QObject):
                 return
             # --------------------------
             self.progress_message.emit(_('Preparing user interface...'))
-            cache.save(original_group)
+
+            # Save all: metadata + TOC + content
+            cache.save(content_originals)
+            for metadata_item in metadata_originals:
+                cache.add(*metadata_item)
+            for toc_item in toc_originals:
+                cache.add(*toc_item)
+            cache.connection.commit()
             self.progress.emit(100)
             d = time.time()
             self.progress_detail.emit('cache timing: %s' % (d - c))
@@ -173,7 +210,7 @@ class TranslationWorker(QObject):
         QObject.__init__(self)
         self.source_lang = ebook.source_lang
         self.target_lang = ebook.target_lang
-        self.engine_class = engine_class
+        self.current_engine = engine_class
 
         self.on_working = False
         self.canceled = False
@@ -188,7 +225,7 @@ class TranslationWorker(QObject):
         self.target_lang = lang
 
     def set_engine_class(self, engine_class):
-        self.engine_class = engine_class
+        self.current_engine = engine_class
 
     def set_canceled(self, canceled):
         self.canceled = canceled
@@ -204,7 +241,7 @@ class TranslationWorker(QObject):
         """:fresh: retranslate all paragraphs."""
         self.on_working = True
         self.start.emit()
-        translator = get_translator(self.engine_class)
+        translator = get_translator(self.current_engine)
         translator.set_source_lang(self.source_lang)
         translator.set_target_lang(self.target_lang)
         translation = get_translation(translator)
@@ -447,13 +484,33 @@ class AdvancedTranslation(QDialog):
             merge_length = self.cache.get_info('merge_length') or 0
             self.merge_enabled = int(merge_length) > 0
             paragraphs = self.cache.all_paragraphs()
-            if len(paragraphs) < 1:
+
+            # Metadata and TOC are already in cache with page='content.opf' and page='toc.ncx'
+            # No need to fetch separately - they're loaded with all_paragraphs()
+            metadata_count = len([p for p in paragraphs if p.page == 'content.opf'])
+            toc_count = len([p for p in paragraphs if p.page == 'toc.ncx'])
+            content_count = len([p for p in paragraphs if p.page not in ('content.opf', 'toc.ncx')])
+
+            from .lib.utils import log
+            from .lib.config import get_config
+            config = get_config()
+            if config.get('log_translation', True):
+                log.info('[ADVANCED UI] Loaded from cache: %d metadata, %d TOC, %d content, %d total' %
+                        (metadata_count, toc_count, content_count, len(paragraphs)))
+                # Log first few items to debug
+                for i, p in enumerate(paragraphs[:15]):
+                    log.info('[ADVANCED UI]   Item %d: page=%s, original="%s"' %
+                            (i, p.page or 'None', p.original[:50]))
+
+            all_items = paragraphs
+
+            if len(all_items) < 1:
                 self.alert.pop(
                     _('There is no content that needs to be translated.'),
                     'warning')
                 self.done(0)
                 return
-            self.table = AdvancedTranslationTable(self, paragraphs)
+            self.table = AdvancedTranslationTable(self, all_items)
             self.panel = self.layout_panel()
             self.stack.addWidget(self.panel)
             self.stack.setCurrentWidget(self.panel)
@@ -973,6 +1030,7 @@ class AdvancedTranslation(QDialog):
         self.review_splitter.setSizes(_size)
 
         def synchronizeScrollbars(editors):
+            """Sync scrollbars between editors using simple pixel-based approach."""
             for editor in editors:
                 for other_editor in editors:
                     if editor != other_editor:
@@ -1113,6 +1171,23 @@ class AdvancedTranslation(QDialog):
         self.table.row.connect(update_translation_status)
 
         def change_selected_item():
+            # TODO: Allow viewing chunk details during translation
+            # Current limitation: Blocks all selection changes during translation to prevent
+            # data corruption with concurrent/streaming translation.
+            #
+            # Problem: With concurrency > 1, multiple paragraphs stream in parallel.
+            # If user clicks paragraph N while paragraph M is streaming, M's chunks would
+            # get inserted into N's view (data corruption). With single-threaded streaming,
+            # we could track current_streaming_row and discard mismatched chunks, but
+            # concurrent signals from multiple threads interleave unpredictably.
+            #
+            # Potential solutions:
+            # 1. Track streaming state per paragraph (dict[row, is_streaming])
+            # 2. Tag each streaming chunk with paragraph row in the signal
+            # 3. Buffer streaming chunks and only insert when paragraph matches
+            # 4. Disable concurrent translation when streaming is enabled
+            #
+            # For now, maintain original guard to prevent corruption.
             if self.trans_worker.on_working:
                 return
             paragraph = self.table.current_paragraph()
@@ -1139,7 +1214,32 @@ class AdvancedTranslation(QDialog):
             elif isinstance(data, Paragraph):
                 self.table.setCurrentItem(self.table.item(data.row, 0))
             else:
-                translation_text.insertPlainText(data)
+                # Streaming text chunk
+                # Check if user is at bottom (watching stream)
+                scrollbar = translation_text.verticalScrollBar()
+                was_at_bottom = scrollbar.value() >= scrollbar.maximum() - 10
+
+                # Disable updates to prevent auto-scroll/flicker
+                translation_text.setUpdatesEnabled(False)
+                saved_position = scrollbar.value()
+
+                # Append to document using cursor at end
+                doc = translation_text.document()
+                cursor = QTextCursor(doc)
+                end_position = getattr(QTextCursor.MoveOperation, 'End', None) or QTextCursor.End
+                cursor.movePosition(end_position)
+                cursor.insertText(data)
+
+                # Restore scroll position before re-enabling updates
+                if not was_at_bottom:
+                    scrollbar.setValue(saved_position)
+
+                # Re-enable updates - this triggers repaint
+                translation_text.setUpdatesEnabled(True)
+
+                # Scroll to bottom only if user was watching
+                if was_at_bottom:
+                    scrollbar.setValue(scrollbar.maximum())
         self.trans_worker.streaming.connect(streaming_translation)
 
         def modify_translation():
@@ -1216,6 +1316,56 @@ class AdvancedTranslation(QDialog):
     def get_progress_step(self, total):
         return int(round(100.0 / (total or 1), 100) * 1000000)
 
+    def check_max_tokens_capacity(self):
+        """Check if merge length might exceed model's max output tokens."""
+        if not issubclass(self.current_engine, ClaudeTranslate):
+            return True  # Only check for Claude models
+
+        config = get_config()
+        merge_length = config.get('merge_length', 1800)
+        merge_enabled = config.get('merge_enabled', False)
+
+        if not merge_enabled:
+            return True  # No merge, chunks will be small
+
+        # Get model and settings from engine
+        engine_config = self.current_engine.config
+        model = engine_config.get('model', self.current_engine.model)
+        enable_extended_output = engine_config.get('enable_extended_output', False)
+
+        # Estimate output tokens (conservative: 3 chars per token, +10% buffer)
+        estimated_output_tokens = int((merge_length / 3) * 1.1)
+
+        # Determine model's max output (same logic as in anthropic.py get_body)
+        if not model:
+            model_max_output = 4_096
+        elif model.startswith('claude-3-7-sonnet-') and enable_extended_output:
+            model_max_output = 128_000
+        elif model.startswith('claude-3-7-sonnet-'):
+            model_max_output = 64_000
+        elif model.startswith('claude-sonnet-4-') or model.startswith('claude-haiku-4-') or \
+             model.startswith('claude-opus-4-5') or model.startswith('claude-opus-4-1'):
+            model_max_output = 64_000
+        elif model.startswith('claude-opus-4-0'):
+            model_max_output = 32_000
+        elif model.startswith('claude-3-haiku-'):
+            model_max_output = 4_000
+        else:
+            model_max_output = 32_000
+
+        # Check if estimated output exceeds model capacity
+        if estimated_output_tokens > model_max_output:
+            message = _(
+                'Warning: Merge length ({:,} chars ≈ {:,} tokens) may exceed model max output ({:,} tokens).\n\n'
+                'This could result in incomplete translations. Consider:\n'
+                '• Reducing merge length\n'
+                '• Enabling "Extended Output" (Claude 3.7 Sonnet: 128K tokens)\n\n'
+                'Continue anyway?'
+            ).format(merge_length, estimated_output_tokens, model_max_output)
+            return self.alert.ask(message) == 'yes'
+
+        return True
+
     def translate_all_paragraphs(self):
         """Translate the untranslated paragraphs when at least one is selected.
         Otherwise, retranslate all paragraphs regardless of prior translation.
@@ -1225,6 +1375,11 @@ class AdvancedTranslation(QDialog):
         if is_fresh:
             paragraphs = self.table.get_selected_paragraphs(False, True)
         self.progress_step = self.get_progress_step(len(paragraphs))
+
+        # Check max_tokens capacity before starting
+        if not self.check_max_tokens_capacity():
+            return
+
         if not self.translate_all:
             message = _(
                 'Are you sure you want to translate all {:n} paragraphs?')
@@ -1239,6 +1394,9 @@ class AdvancedTranslation(QDialog):
         if len(paragraphs) == self.table.rowCount():
             self.translate_all_paragraphs()
         else:
+            # Check max_tokens capacity before starting
+            if not self.check_max_tokens_capacity():
+                return
             self.progress_step = self.get_progress_step(len(paragraphs))
             self.trans_worker.translate.emit(paragraphs, True)
 

--- a/components/table.py
+++ b/components/table.py
@@ -31,9 +31,9 @@ class AdvancedTranslationTable(QTableWidget):
 
     def layout(self):
         self.setRowCount(len(self.paragraphs))
-        self.setColumnCount(4)
+        self.setColumnCount(5)
         self.setHorizontalHeaderLabels(
-            [_('Original'), _('Engine'), _('Language'), _('Status')])
+            [_('Type'), _('Original'), _('Engine'), _('Language'), _('Status')])
         self.verticalHeader().setMinimumWidth(28)
         self.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
@@ -51,43 +51,60 @@ class AdvancedTranslationTable(QTableWidget):
             vheader.setTextAlignment(Qt.AlignCenter)
             self.setVerticalHeaderItem(row, vheader)
 
+            metadata_col = QTableWidgetItem()
+            metadata_col.setTextAlignment(Qt.AlignCenter)
+            metadata_col.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)
+            metadata_col.setData(Qt.UserRole, paragraph)  # Store paragraph in first column
             original = QTableWidgetItem()
             original.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)
-            original.setData(Qt.UserRole, paragraph)
             engine_name = QTableWidgetItem()
             engine_name.setTextAlignment(Qt.AlignCenter)
             traget_lang = QTableWidgetItem()
             traget_lang.setTextAlignment(Qt.AlignCenter)
             status = QTableWidgetItem()
             status.setTextAlignment(Qt.AlignCenter)
-            self.setItem(row, 0, original)
-            self.setItem(row, 1, engine_name)
-            self.setItem(row, 2, traget_lang)
-            self.setItem(row, 3, status)
+            self.setItem(row, 0, metadata_col)
+            self.setItem(row, 1, original)
+            self.setItem(row, 2, engine_name)
+            self.setItem(row, 3, traget_lang)
+            self.setItem(row, 4, status)
 
             self.track_row_data(row)
 
         header = self.horizontalHeader()
-        header.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+        header.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)  # Original column stretches
 
     def track_row_data(self, row):
         paragraph = self.paragraph(row)
         original = paragraph.original.replace('\n', ' ')
         engine_name = paragraph.engine_name
         target_lang = paragraph.target_lang
-        items = [original, '--', '--', _('Untranslated')]
+
+        # Check type based on page
+        is_metadata = paragraph.page == 'content.opf'
+        is_toc = paragraph.page == 'toc.ncx'
+        type_indicator = ''
+        if is_metadata:
+            type_indicator = 'Metadata'
+        elif is_toc:
+            type_indicator = 'TOC'
+
+        items = [type_indicator, original, '--', '--', _('Untranslated')]
         if paragraph.translation:
-            before_aligned = paragraph.aligned
-            if self.parent.merge_enabled:
-                self.check_line_alignment(paragraph)
-            # If the alignment of before and after is the same, do nothing.
-            if before_aligned and not paragraph.aligned:
-                self.non_aligned_count += 1
-            elif not before_aligned and paragraph.aligned:
-                self.non_aligned_count -= 1
-            items = [original, engine_name, target_lang, _('Translated')]
+            if not is_metadata and not is_toc:
+                # Only check alignment for content, not metadata/TOC
+                before_aligned = paragraph.aligned
+                if self.parent.merge_enabled:
+                    self.check_line_alignment(paragraph)
+                # If the alignment of before and after is the same, do nothing.
+                if before_aligned and not paragraph.aligned:
+                    self.non_aligned_count += 1
+                elif not before_aligned and paragraph.aligned:
+                    self.non_aligned_count -= 1
+            items = [type_indicator, original, engine_name, target_lang, _('Translated')]
         else:
-            self.check_translation_error(paragraph)
+            if not is_metadata and not is_toc:
+                self.check_translation_error(paragraph)
         for column, text in enumerate(items):
             item = self.item(row, column)
             item.setText(text)

--- a/lib/cache.py
+++ b/lib/cache.py
@@ -11,7 +11,7 @@ from glob import glob
 
 from calibre.utils.localization import _  # type: ignore
 
-from .utils import size_by_unit
+from .utils import size_by_unit, log
 from .config import get_config
 
 
@@ -301,6 +301,7 @@ class TranslationCache:
         paragraphs = []
         for item in self.all():
             paragraph = Paragraph(*item)
+            # In cache_only mode, skip paragraphs without translations
             if self.cache_only and not paragraph.translation:
                 continue
             paragraphs.append(paragraph)

--- a/lib/config.py
+++ b/lib/config.py
@@ -24,6 +24,7 @@ defaults: dict[str, Any] = {
     'cache_enabled': True,
     'cache_path': None,
     'log_translation': True,
+    'log_content': True,
     'show_notification': True,
     'translation_position': None,
     'column_gap': {
@@ -117,6 +118,8 @@ def upgrade_config():
         ver205_upgrade(config)
     if version >= (2, 4, 0):  # type: ignore
         ver240_upgrade()
+    if version >= (2, 4, 2):  # type: ignore
+        ver242_upgrade(config)
 
 
 def ver200_upgrade(config):
@@ -219,3 +222,32 @@ def ver240_upgrade():
         os.rename(
             os.path.join(new_config_path, EbookTranslator.identifier + '.ini'),
             os.path.join(new_config_path, 'settings.ini'))
+
+
+def ver242_upgrade(config):
+    """Migrate old metadata_translation flag to new individual field flags."""
+    ebook_metadata = config.get('ebook_metadata') or {}
+
+    # Check if migration needed
+    if 'metadata_translation' not in ebook_metadata:
+        return  # Nothing to migrate
+
+    # Migrate old flag to new individual field flags
+    old_value = ebook_metadata.get('metadata_translation', False)
+    if 'translate_title' not in ebook_metadata:
+        # New flags don't exist yet - create them all from old value
+        ebook_metadata['translate_title'] = old_value
+        ebook_metadata['translate_creator'] = old_value
+        ebook_metadata['translate_publisher'] = old_value
+        ebook_metadata['translate_series'] = old_value
+        ebook_metadata['translate_creator_file_as'] = old_value
+        ebook_metadata['translate_rights'] = old_value
+        ebook_metadata['translate_subject'] = old_value
+        ebook_metadata['translate_contributor'] = old_value
+        ebook_metadata['translate_description'] = old_value
+
+    # Remove old key
+    del ebook_metadata['metadata_translation']
+
+    # Save migrated config
+    config.save(ebook_metadata=ebook_metadata)

--- a/lib/conversion.py
+++ b/lib/conversion.py
@@ -18,7 +18,7 @@ from calibre.ebooks.metadata.meta import (  # type: ignore
 from .. import EbookTranslator
 
 from .config import get_config
-from .utils import log, sep, uid, open_path, open_file
+from .utils import log, sep, open_path, open_file
 from .cache import get_cache
 from .element import (
     get_element_handler, get_srt_elements, get_toc_elements, get_page_elements,
@@ -61,18 +61,337 @@ def convert_book(
         self.report_progress = CompositeProgressReporter(0, 1, notification)
         log.info('Translating ebook content... (this will take a while)')
         log.info(debug_info)
+
+        # Log all plugin settings if log_translation is enabled
+        config = get_config()
+        if config.get('log_translation', True):
+            log.info(sep())
+            log.info('Plugin Settings:')
+            log.info(sep('┈'))
+            log.info('  Translation Position: %s' % config.get('translation_position'))
+            log.info('  Merge Enabled: %s' % config.get('merge_enabled'))
+            if config.get('merge_enabled'):
+                log.info('  Merge Length: %s' % config.get('merge_length'))
+            log.info('  Cache Enabled: %s' % config.get('cache_enabled'))
+            log.info('  Translate Missing Metadata: %s' % config.get('translate_missing_metadata', False))
+            log.info('  Log Translation: %s' % config.get('log_translation', True))
+            log.info('  Log Content: %s' % config.get('log_content', True))
+            log.info('  Original Color: %s' % config.get('original_color'))
+            log.info('  Translation Color: %s' % config.get('translation_color'))
+            log.info('  Filter Scope: %s' % config.get('filter_scope'))
+            log.info('  Rule Mode: %s' % config.get('rule_mode'))
+            log.info('  Glossary Enabled: %s' % config.get('glossary_enabled'))
+
+            ebook_metadata = config.get('ebook_metadata', {})
+            if ebook_metadata:
+                log.info('  Metadata Translation Settings:')
+                for key, value in ebook_metadata.items():
+                    log.info('    %s: %s' % (key, value))
+            log.info(sep())
+
         translation.set_progress(self.report_progress)
 
-        elements.extend(get_metadata_elements(oeb.metadata))
-        # The number of elements may vary with format conversion.
-        elements.extend(get_toc_elements(oeb.toc.nodes, []))
-        elements.extend(get_page_elements(oeb.manifest.items))
-        original_group = element_handler.prepare_original(elements)
-        cache.save(original_group)
+        config = get_config()
+        ebook_metadata_config = config.get('ebook_metadata') or {}
 
-        paragraphs = cache.all_paragraphs()
-        translation.handle(paragraphs)
-        element_handler.add_translations(paragraphs)
+        # Handle metadata separately from content (not merged, individual cache entries)
+        # Always extract and store metadata, even if translation is disabled (for UI display)
+        from .utils import uid
+        metadata_elements = get_metadata_elements(oeb.metadata)
+        metadata_element_map = {}  # Map original text to element for applying translations
+
+        metadata_originals = []
+        metadata_field_names = {}  # Map item_id to field name for logging
+        # Store metadata originals directly in cache (bypass element_handler)
+        # Only store ENABLED metadata fields (ignored ones don't appear in UI)
+        for eid, metadata_elem in enumerate(metadata_elements):
+            if metadata_elem.ignored:
+                continue  # Skip disabled metadata fields
+
+            original_value = metadata_elem.get_content()
+            # Use negative IDs to avoid conflicts with content
+            item_id = -(eid + 1)
+            md5 = uid('metadata_%s%s' % (eid, original_value))
+
+            # Determine field name from OEB metadata
+            field_name = 'unknown'
+            for key in oeb.metadata.iterkeys():
+                items = getattr(oeb.metadata, key)
+                for item in items:
+                    if item == metadata_elem.element:
+                        field_name = key
+                        break
+                if field_name != 'unknown':
+                    break
+
+            # Store as 7-tuple with page='content.opf'
+            # Only enabled metadata appears in UI
+            metadata_originals.append((item_id, md5, original_value, original_value, False, None, 'content.opf'))
+            metadata_field_names[item_id] = field_name
+            metadata_element_map[original_value] = metadata_elem
+
+        # Handle TOC separately - merge all TOC entries into one paragraph
+        toc_elements = get_toc_elements(oeb.toc.nodes, [])
+        toc_originals = []
+        toc_element_list = []  # Keep references for applying translations
+
+        if toc_elements:
+            # Merge all TOC entries with separator
+            toc_texts = []
+            for toc_elem in toc_elements:
+                if not toc_elem.ignored:
+                    toc_texts.append(toc_elem.get_content())
+                    toc_element_list.append(toc_elem)
+
+            if toc_texts:
+                merged_toc = '\n\n'.join(toc_texts)
+                toc_id = 'toc_merged'
+                md5 = uid('toc_%s' % merged_toc)
+                # Store merged TOC as single entry with page='toc.ncx'
+                toc_originals.append((toc_id, md5, merged_toc, merged_toc, False, None, 'toc.ncx'))
+
+        # Extract content/page elements only (no TOC, no metadata)
+        elements.extend(list(get_page_elements(oeb.manifest.items)))
+        content_originals = element_handler.prepare_original(elements)
+
+        # Synchronize cache with current extraction
+        if config.get('log_translation', True):
+            log.info('[CACHE] Preparing to save: %d metadata, %d TOC, %d content' %
+                    (len(metadata_originals), len(toc_originals), len(content_originals)))
+
+        if cache.is_fresh():
+            # Fresh cache - just save everything
+            if config.get('log_translation', True):
+                log.info('[CACHE] Fresh cache - saving all entries')
+
+            cache.save(content_originals)
+
+            if config.get('log_translation', True):
+                log.info('[CACHE] Content saved, adding %d metadata entries' % len(metadata_originals))
+
+            for metadata_item in metadata_originals:
+                cache.add(*metadata_item)
+
+            if config.get('log_translation', True):
+                log.info('[CACHE] Metadata added, adding %d TOC entries' % len(toc_originals))
+
+            for toc_item in toc_originals:
+                cache.add(*toc_item)
+
+            cache.connection.commit()
+
+            if config.get('log_translation', True):
+                log.info('[CACHE] All entries saved and committed')
+        else:
+            # Existing cache - synchronize structure
+            # 1. Remove obsolete entries (content paragraphs that no longer exist)
+            # 2. Add missing entries (new metadata, TOC, or content)
+
+            # Get current cache IDs
+            existing_ids = set([item[0] for item in cache.cursor.execute('SELECT id FROM cache').fetchall()])
+
+            # Get new IDs from current extraction
+            new_content_ids = set([item[0] for item in content_originals])
+            new_metadata_ids = set([item[0] for item in metadata_originals])
+            new_toc_ids = set([item[0] for item in toc_originals])
+            new_all_ids = new_content_ids | new_metadata_ids | new_toc_ids
+
+            # Find IDs to remove (in cache but not in new extraction)
+            # Only remove if current extraction is complete (has content)
+            if len(content_originals) > 0:
+                ids_to_remove = existing_ids - new_all_ids
+                if ids_to_remove:
+                    placeholders = ', '.join(['?'] * len(ids_to_remove))
+                    cache.cursor.execute(
+                        'DELETE FROM cache WHERE id IN (%s)' % placeholders,
+                        tuple(ids_to_remove))
+                    if config.get('log_translation', True):
+                        log.info('[CACHE SYNC] Removed %d obsolete entries' % len(ids_to_remove))
+
+            # Add missing metadata entries
+            metadata_added = 0
+            for metadata_item in metadata_originals:
+                item_id = metadata_item[0]
+                if item_id not in existing_ids:
+                    cache.add(*metadata_item)
+                    metadata_added += 1
+                    field_name = metadata_field_names.get(item_id, 'unknown')
+                    if config.get('log_translation', True):
+                        log.info('[CACHE SYNC] Added metadata [%s]: "%s"' %
+                                (field_name, metadata_item[3][:50]))
+
+            # Add missing TOC entry
+            toc_added = 0
+            for toc_item in toc_originals:
+                item_id = toc_item[0]
+                if item_id not in existing_ids:
+                    cache.add(*toc_item)
+                    toc_added += 1
+                    if config.get('log_translation', True):
+                        log.info('[CACHE SYNC] Added merged TOC entry')
+
+            if metadata_added > 0 or toc_added > 0:
+                cache.connection.commit()
+                if config.get('log_translation', True):
+                    if metadata_added > 0:
+                        log.info('[CACHE SYNC] Added %d metadata entries to existing cache' % metadata_added)
+                    if toc_added > 0:
+                        log.info('[CACHE SYNC] Added TOC entry to existing cache')
+
+        # Load all paragraphs from cache
+        all_paragraphs = cache.all_paragraphs()
+
+        # Separate metadata, TOC, and content
+        metadata_paragraphs = [p for p in all_paragraphs if p.page == 'content.opf']
+        toc_paragraphs = [p for p in all_paragraphs if p.page == 'toc.ncx']
+        content_paragraphs = [p for p in all_paragraphs if p.page not in ('content.opf', 'toc.ncx')]
+
+        # Translate metadata fields separately
+        if metadata_paragraphs:
+            log.info(sep())
+            log.info(_('Translating metadata fields...'))
+            log.info(sep('┈'))
+
+            # Disable streaming for metadata
+            original_stream = translation.translator.stream
+            translation.translator.stream = False
+
+            # Track which fields exist to avoid auto-populating sort fields
+            existing_fields = set()
+            for meta_para in metadata_paragraphs:
+                # Determine field name from original value
+                for key in oeb.metadata.iterkeys():
+                    items = getattr(oeb.metadata, key)
+                    for item in items:
+                        if item.content == meta_para.original:
+                            existing_fields.add(key)
+                            break
+
+            # Store translated title/creator for auto-populating sort fields
+            translated_title = None
+            translated_creators = []
+
+            for meta_para in metadata_paragraphs:
+                # Determine which field this paragraph belongs to
+                field_name = None
+                for key in oeb.metadata.iterkeys():
+                    items = getattr(oeb.metadata, key)
+                    for item in items:
+                        if item.content == meta_para.original:
+                            field_name = key
+                            break
+                    if field_name:
+                        break
+
+                # Skip if already translated and not fresh
+                if meta_para.translation and not translation.fresh:
+                    if config.get('log_translation', True):
+                        log.info('✓ Metadata cached: "%s" → "%s"' %
+                                (meta_para.original[:50], meta_para.translation[:50]))
+                    # Apply cached translation to element
+                    if meta_para.original in metadata_element_map:
+                        metadata_element_map[meta_para.original].element.content = meta_para.translation
+
+                    # Track for auto-populating sort fields
+                    if field_name == 'title':
+                        translated_title = meta_para.translation
+                    elif field_name == 'creator':
+                        translated_creators.append(meta_para.translation)
+                    continue
+
+                # Translate this metadata field
+                if config.get('log_translation', True):
+                    log.info('○ Translating metadata [%s]: "%s"' % (field_name or 'unknown', meta_para.original[:50]))
+
+                try:
+                    result = translation.translator.translate(meta_para.original)
+                    if hasattr(result, '__iter__') and not isinstance(result, str):
+                        result = ''.join(result)
+                    if result and result.strip():
+                        meta_para.translation = result.strip()
+                        meta_para.engine_name = translation.translator.name
+                        meta_para.target_lang = translation.translator.get_target_lang()
+                        # Update cache
+                        cache.update_paragraph(meta_para)
+                        # Apply to OEB element
+                        if meta_para.original in metadata_element_map:
+                            metadata_element_map[meta_para.original].element.content = meta_para.translation
+
+                        # Track for auto-populating sort fields
+                        if field_name == 'title':
+                            translated_title = meta_para.translation
+                        elif field_name == 'creator':
+                            translated_creators.append(meta_para.translation)
+
+                        if config.get('log_translation', True):
+                            log.info('  → "%s"' % meta_para.translation[:50])
+                except Exception as e:
+                    log.error('Failed to translate metadata: %s' % e)
+
+            # Auto-populate title_sort if title was translated and title_sort doesn't exist
+            if translated_title and 'title_sort' not in existing_fields:
+                oeb.metadata.add('title_sort', translated_title)
+                if config.get('log_translation', True):
+                    log.info('✓ Auto-populated title_sort: "%s"' % translated_title[:50])
+
+            # Auto-populate author_sort if creator was translated and author_sort doesn't exist
+            if translated_creators and 'author_sort' not in existing_fields:
+                # Use first creator for author_sort
+                oeb.metadata.add('author_sort', translated_creators[0])
+                if config.get('log_translation', True):
+                    log.info('✓ Auto-populated author_sort: "%s"' % translated_creators[0][:50])
+
+            # Restore streaming
+            translation.translator.stream = original_stream
+            log.info(sep())
+
+        # Translate TOC (merged paragraph)
+        if toc_paragraphs:
+            log.info(sep())
+            log.info(_('Translating TOC...'))
+            log.info(sep('┈'))
+
+            for toc_para in toc_paragraphs:
+                # Skip if already translated and not fresh
+                if toc_para.translation and not translation.fresh:
+                    if config.get('log_translation', True):
+                        log.info('✓ TOC cached')
+                else:
+                    # Translate merged TOC
+                    if config.get('log_translation', True):
+                        log.info('○ Translating merged TOC')
+
+                    try:
+                        result = translation.translator.translate(toc_para.original)
+                        if hasattr(result, '__iter__') and not isinstance(result, str):
+                            result = ''.join(result)
+                        if result and result.strip():
+                            toc_para.translation = result.strip()
+                            toc_para.engine_name = translation.translator.name
+                            toc_para.target_lang = translation.translator.get_target_lang()
+                            cache.update_paragraph(toc_para)
+                            if config.get('log_translation', True):
+                                log.info('  → TOC translated')
+                    except Exception as e:
+                        log.error('Failed to translate TOC: %s' % e)
+
+                # Split translated TOC back to individual elements
+                if toc_para.translation and toc_element_list:
+                    translated_parts = toc_para.translation.split('\n\n')
+                    for i, toc_elem in enumerate(toc_element_list):
+                        if i < len(translated_parts):
+                            toc_elem.element.title = translated_parts[i].strip()
+
+            log.info(sep())
+
+        # Translate content using normal paragraph system
+        translation.handle(content_paragraphs)
+
+        # Apply content translations to elements
+        element_handler.add_translations(content_paragraphs)
+
+        # RTL/LTR metadata will be added in translate_done() phase
+        # (after EPUB file is written, so we can directly modify the OPF)
 
         log.info(sep())
         log.info(_('Start to convert ebook format...'))
@@ -201,13 +520,12 @@ def convert_item(
         translator.placeholder, translator.separator, direction)
     element_handler.set_translation_lang(
         translator.get_iso639_target_code(target_lang))
+    element_handler.set_source_lang(
+        translator.get_source_code(translator.source_lang))
 
-    merge_length = str(element_handler.get_merge_length())
-    _encoding = ''
-    if encoding.lower() != 'utf-8':
-        _encoding = encoding.lower()
-    cache_id = uid(
-        input_path + translator.name + target_lang + merge_length + _encoding)
+    from .utils import get_cache_id
+    merge_length = element_handler.get_merge_length()
+    cache_id = get_cache_id(input_path, translator.name, target_lang, merge_length, encoding)
     cache = get_cache(cache_id)
     cache.set_cache_only(cache_only)
     cache.set_info('title', ebook_title)
@@ -216,6 +534,8 @@ def convert_item(
     cache.set_info('merge_length', merge_length)
     cache.set_info('plugin_version', EbookTranslator.__version__)
     cache.set_info('calibre_version', __version__)
+    cache.set_info('source_lang', source_lang)
+    cache.set_info('target_direction', direction)
 
     translation = get_translation(
         translator, lambda text, error=False: log.info(text))
@@ -243,6 +563,7 @@ def convert_item(
     convertor(
         input_path, output_path, translation, element_handler, cache,
         debug_info, encoding, notification)
+
     cache.done()
 
 
@@ -279,10 +600,11 @@ class ConversionWorker:
                  ebook.encoding, ebook.target_direction)),
             description=(_('[{} > {}] Translating "{}"').format(
                 ebook.source_lang, ebook.target_lang, ebook.title)))
-        self.working_jobs[job] = (ebook, output_path)
+        self.working_jobs[job] = (ebook, output_path, cache_only)
 
     def translate_done(self, job):
-        ebook, output_path = self.working_jobs.pop(job)
+        ebook, output_path, cache_only = self.working_jobs.pop(job)
+        log.info('translate_done called: cache_only=%s, format=%s' % (cache_only, ebook.output_format))
 
         if job.failed:
             if not DEBUG:
@@ -292,23 +614,75 @@ class ConversionWorker:
 
         # TODO: Try to use the calibre generated metadata file.
         ebook_metadata_config = self.config.get('ebook_metadata') or {}
+        log.info('ebook_metadata_config: %s' % ebook_metadata_config)
+        log.info('is_extra_format: %s' % ebook.is_extra_format())
+
         if not ebook.is_extra_format():
             with open(output_path, 'r+b') as file:
                 metadata = get_metadata(file, ebook.output_format)
+                log.info('Read metadata from file: title=%s, authors=%s, publisher=%s, series=%s' % (
+                    metadata.title, metadata.authors, metadata.publisher, metadata.series))
+
+                # Add RTL/LTR metadata to OPF if directions differ
+                # Do this by directly modifying the EPUB's content.opf file
+                from lxml import etree
+                from ..engines.languages import lang_directionality
+
+                translator = get_translator()
+                source_lang_code = translator.get_source_code(ebook.source_lang)
+                source_lang_base = source_lang_code.split('-')[0] if source_lang_code else None
+                source_direction = lang_directionality.get(source_lang_code,
+                                                          lang_directionality.get(source_lang_base, 'ltr'))
+                target_direction = ebook.target_direction.lower() if ebook.target_direction else None
+
+                if target_direction in ('rtl', 'ltr') and source_direction != target_direction:
+                    try:
+                        from calibre.ebooks.oeb.polish.container import get_container
+                        from lxml import etree
+
+                        writing_mode = 'horizontal-rl' if target_direction == 'rtl' else 'horizontal-lr'
+
+                        # Use Calibre's polish Container for efficient EPUB modification
+                        container = get_container(output_path, tweak_mode=True)
+                        opf_root = container.opf
+
+                        # Add primary-writing-mode meta
+                        ns = {'opf': 'http://www.idpf.org/2007/opf'}
+                        metadata_elem = opf_root.xpath('//opf:metadata', namespaces=ns)[0]
+                        etree.SubElement(metadata_elem, '{http://www.idpf.org/2007/opf}meta',
+                                        attrib={'name': 'primary-writing-mode', 'content': writing_mode})
+
+                        # Set spine page-progression-direction
+                        spine_elem = opf_root.xpath('//opf:spine', namespaces=ns)[0]
+                        spine_elem.set('page-progression-direction', target_direction)
+
+                        # Commit changes - Container efficiently updates only the OPF file in ZIP
+                        container.dirty(container.opf_name)
+                        container.commit()
+
+                        log.info('Added RTL metadata: primary-writing-mode=%s, page-progression-direction=%s' %
+                                (writing_mode, target_direction))
+                    except Exception as e:
+                        log.warn('Failed to add RTL metadata to EPUB: %s' % e)
+
                 ebook_title = metadata.title
                 if ebook.custom_title is not None:
                     ebook_title = ebook.custom_title
                 if ebook_metadata_config.get('lang_mark'):
                     ebook_title = '%s [%s]' % (ebook_title, ebook.target_lang)
                 metadata.title = ebook_title
-                if ebook_metadata_config.get('lang_code'):
+
+                # Update title_sort to match (custom title or translated title with suffix)
+                if ebook_metadata_config.get('translate_title', False):
+                    metadata.title_sort = ebook_title
+
+                if ebook_metadata_config.get('lang_code', True):
                     metadata.language = ebook.lang_code
                 subjects = ebook_metadata_config.get('subjects')
                 metadata.tags += (subjects or []) + [
                     'Translated by Ebook Translator: '
                     'https://translator.bookfere.com']
                 # metadata.authors = ['bookfere.com']
-                # metadata.author_sort = 'bookfere.com'
                 # metadata.book_producer = 'Ebook Translator'
                 set_metadata(file, metadata, ebook.output_format)
         else:

--- a/lib/conversion.py
+++ b/lib/conversion.py
@@ -520,8 +520,6 @@ def convert_item(
         translator.placeholder, translator.separator, direction)
     element_handler.set_translation_lang(
         translator.get_iso639_target_code(target_lang))
-    element_handler.set_source_lang(
-        translator.get_source_code(translator.source_lang))
 
     from .utils import get_cache_id
     merge_length = element_handler.get_merge_length()
@@ -622,48 +620,6 @@ class ConversionWorker:
                 metadata = get_metadata(file, ebook.output_format)
                 log.info('Read metadata from file: title=%s, authors=%s, publisher=%s, series=%s' % (
                     metadata.title, metadata.authors, metadata.publisher, metadata.series))
-
-                # Add RTL/LTR metadata to OPF if directions differ
-                # Do this by directly modifying the EPUB's content.opf file
-                from lxml import etree
-                from ..engines.languages import lang_directionality
-
-                translator = get_translator()
-                source_lang_code = translator.get_source_code(ebook.source_lang)
-                source_lang_base = source_lang_code.split('-')[0] if source_lang_code else None
-                source_direction = lang_directionality.get(source_lang_code,
-                                                          lang_directionality.get(source_lang_base, 'ltr'))
-                target_direction = ebook.target_direction.lower() if ebook.target_direction else None
-
-                if target_direction in ('rtl', 'ltr') and source_direction != target_direction:
-                    try:
-                        from calibre.ebooks.oeb.polish.container import get_container
-                        from lxml import etree
-
-                        writing_mode = 'horizontal-rl' if target_direction == 'rtl' else 'horizontal-lr'
-
-                        # Use Calibre's polish Container for efficient EPUB modification
-                        container = get_container(output_path, tweak_mode=True)
-                        opf_root = container.opf
-
-                        # Add primary-writing-mode meta
-                        ns = {'opf': 'http://www.idpf.org/2007/opf'}
-                        metadata_elem = opf_root.xpath('//opf:metadata', namespaces=ns)[0]
-                        etree.SubElement(metadata_elem, '{http://www.idpf.org/2007/opf}meta',
-                                        attrib={'name': 'primary-writing-mode', 'content': writing_mode})
-
-                        # Set spine page-progression-direction
-                        spine_elem = opf_root.xpath('//opf:spine', namespaces=ns)[0]
-                        spine_elem.set('page-progression-direction', target_direction)
-
-                        # Commit changes - Container efficiently updates only the OPF file in ZIP
-                        container.dirty(container.opf_name)
-                        container.commit()
-
-                        log.info('Added RTL metadata: primary-writing-mode=%s, page-progression-direction=%s' %
-                                (writing_mode, target_direction))
-                    except Exception as e:
-                        log.warn('Failed to add RTL metadata to EPUB: %s' % e)
 
                 ebook_title = metadata.title
                 if ebook.custom_title is not None:

--- a/lib/element.py
+++ b/lib/element.py
@@ -37,7 +37,6 @@ class Element:
 
         self.position = None
         self.target_direction = None
-        self.source_lang = None
         self.translation_lang = None
         self.original_color = None
         self.translation_color = None
@@ -62,9 +61,6 @@ class Element:
 
     def set_target_direction(self, direction):
         self.target_direction = direction
-
-    def set_source_lang(self, lang):
-        self.source_lang = lang
 
     def set_translation_lang(self, lang):
         self.translation_lang = lang
@@ -266,43 +262,13 @@ class PageElement(Element):
         new_element.set('dir', self.target_direction or 'auto')
         if self.translation_lang is not None:
             new_element.set('lang', self.translation_lang)
-
-        # Build style attribute with color and conditional text-align
-        style_parts = []
         if self.translation_color is not None:
-            style_parts.append('color:%s' % self.translation_color)
-
-        # Add text-align only if source and target directions differ
-        if self.source_lang and self.target_direction in ('rtl', 'ltr'):
-            # Import to get directionality function
-            from ..engines.languages import lang_directionality
-            source_direction = lang_directionality.get(self.source_lang, 'ltr')
-
-            # Only add text-align if directions differ
-            if source_direction != self.target_direction:
-                if self.target_direction == 'rtl':
-                    style_parts.append('text-align:right')
-                elif self.target_direction == 'ltr':
-                    style_parts.append('text-align:left')
-
-        if style_parts:
-            new_element.set('style', ';'.join(style_parts))
-
+            new_element.set('style', 'color:%s' % self.translation_color)
         return new_element
 
     def add_translation(self, translation=None):
         # self.element.tail = None  # Make sure the element has no tail
-        if self.original_color is not None or (self.source_lang and self.target_direction in ('rtl', 'ltr')):
-            # Check if text-align should be added (only if directions differ)
-            add_text_align = False
-            text_align_value = None
-            if self.source_lang and self.target_direction in ('rtl', 'ltr'):
-                from ..engines.languages import lang_directionality
-                source_direction = lang_directionality.get(self.source_lang, 'ltr')
-                if source_direction != self.target_direction:
-                    add_text_align = True
-                    text_align_value = 'right' if self.target_direction == 'rtl' else 'left'
-
+        if self.original_color is not None:
             for element in self.element.iter():
                 if element.text is not None or len(list(element)) > 0:
                     # Some users encountered errors when trying to set the
@@ -312,13 +278,7 @@ class PageElement(Element):
                     # since comment and processing instruction nodes do not
                     # have string tags, e.g., etree.Comment and etree.PI.
                     try:
-                        style_parts = []
-                        if self.original_color is not None:
-                            style_parts.append('color:%s' % self.original_color)
-                        if add_text_align:
-                            style_parts.append('text-align:%s' % text_align_value)
-                        if style_parts:
-                            element.set('style', ';'.join(style_parts))
+                        element.set('style', 'color:%s' % self.original_color)
                     except TypeError:
                         log.warn(
                             'Failed to set style on element:',
@@ -682,7 +642,6 @@ class ElementHandler:
 
         self.merge_length = 0
         self.target_direction = None
-        self.source_lang = None
 
         self.translation_lang = None
         self.original_color = None
@@ -703,9 +662,6 @@ class ElementHandler:
 
     def set_target_direction(self, direction):
         self.target_direction = direction
-
-    def set_source_lang(self, lang):
-        self.source_lang = lang
 
     def set_translation_lang(self, lang):
         self.translation_lang = lang
@@ -738,7 +694,6 @@ class ElementHandler:
             element.set_placeholder(self.placeholder)
             element.set_position(self.position)
             element.set_target_direction(self.target_direction)
-            element.set_source_lang(self.source_lang)
             element.set_translation_lang(self.translation_lang)
             element.set_original_color(self.original_color)
             element.set_translation_color(self.translation_color)
@@ -795,7 +750,6 @@ class ElementHandlerMerge(ElementHandler):
             element.set_placeholder(self.placeholder)
             element.set_position(self.position)
             element.set_target_direction(self.target_direction)
-            element.set_source_lang(self.source_lang)
             element.set_translation_lang(self.translation_lang)
             element.set_original_color(self.original_color)
             element.set_translation_color(self.translation_color)
@@ -884,19 +838,15 @@ def get_pgn_elements(path, encoding):
 def get_metadata_elements(metadata):
     """Extract metadata elements for separate translation (not as paragraphs).
 
-    Metadata is translated individually and cached in info table, not paragraph table.
-    Each field is displayed separately in UI, not mixed with content paragraphs.
+    Metadata is translated individually and cached separately, not merged with content.
+    Each field is displayed separately in UI with Type column indicator.
 
-    Extracts all 9 metadata fields:
-    - title (dc:title)
-    - creator (dc:creator)
+    Extracts all metadata fields:
+    - title, title_sort (dc:title, calibre:title_sort)
+    - creator, author_sort (dc:creator, calibre:author_sort)
     - publisher (dc:publisher)
     - series (calibre:series)
-    - author_sort (calibre:author_sort / opf:file-as)
-    - rights (dc:rights)
-    - subject (dc:subject)
-    - contributor (dc:contributor)
-    - description (dc:description)
+    - rights, subject, contributor, description
 
     Each field respects individual translation settings from config.
     """
@@ -959,7 +909,7 @@ def get_metadata_elements(metadata):
         for item in items:
             if pattern.search(item.content) is None:
                 continue
-            # Store element reference for translation, but mark ignored for paragraph system
+            # Store element reference for translation
             element = MetadataElement(
                 item, page_id='content.opf', ignored=not should_translate)
             elements.append(element)

--- a/lib/element.py
+++ b/lib/element.py
@@ -37,6 +37,7 @@ class Element:
 
         self.position = None
         self.target_direction = None
+        self.source_lang = None
         self.translation_lang = None
         self.original_color = None
         self.translation_color = None
@@ -61,6 +62,9 @@ class Element:
 
     def set_target_direction(self, direction):
         self.target_direction = direction
+
+    def set_source_lang(self, lang):
+        self.source_lang = lang
 
     def set_translation_lang(self, lang):
         self.translation_lang = lang
@@ -262,13 +266,43 @@ class PageElement(Element):
         new_element.set('dir', self.target_direction or 'auto')
         if self.translation_lang is not None:
             new_element.set('lang', self.translation_lang)
+
+        # Build style attribute with color and conditional text-align
+        style_parts = []
         if self.translation_color is not None:
-            new_element.set('style', 'color:%s' % self.translation_color)
+            style_parts.append('color:%s' % self.translation_color)
+
+        # Add text-align only if source and target directions differ
+        if self.source_lang and self.target_direction in ('rtl', 'ltr'):
+            # Import to get directionality function
+            from ..engines.languages import lang_directionality
+            source_direction = lang_directionality.get(self.source_lang, 'ltr')
+
+            # Only add text-align if directions differ
+            if source_direction != self.target_direction:
+                if self.target_direction == 'rtl':
+                    style_parts.append('text-align:right')
+                elif self.target_direction == 'ltr':
+                    style_parts.append('text-align:left')
+
+        if style_parts:
+            new_element.set('style', ';'.join(style_parts))
+
         return new_element
 
     def add_translation(self, translation=None):
         # self.element.tail = None  # Make sure the element has no tail
-        if self.original_color is not None:
+        if self.original_color is not None or (self.source_lang and self.target_direction in ('rtl', 'ltr')):
+            # Check if text-align should be added (only if directions differ)
+            add_text_align = False
+            text_align_value = None
+            if self.source_lang and self.target_direction in ('rtl', 'ltr'):
+                from ..engines.languages import lang_directionality
+                source_direction = lang_directionality.get(self.source_lang, 'ltr')
+                if source_direction != self.target_direction:
+                    add_text_align = True
+                    text_align_value = 'right' if self.target_direction == 'rtl' else 'left'
+
             for element in self.element.iter():
                 if element.text is not None or len(list(element)) > 0:
                     # Some users encountered errors when trying to set the
@@ -278,7 +312,13 @@ class PageElement(Element):
                     # since comment and processing instruction nodes do not
                     # have string tags, e.g., etree.Comment and etree.PI.
                     try:
-                        element.set('style', 'color:%s' % self.original_color)
+                        style_parts = []
+                        if self.original_color is not None:
+                            style_parts.append('color:%s' % self.original_color)
+                        if add_text_align:
+                            style_parts.append('text-align:%s' % text_align_value)
+                        if style_parts:
+                            element.set('style', ';'.join(style_parts))
                     except TypeError:
                         log.warn(
                             'Failed to set style on element:',
@@ -642,6 +682,7 @@ class ElementHandler:
 
         self.merge_length = 0
         self.target_direction = None
+        self.source_lang = None
 
         self.translation_lang = None
         self.original_color = None
@@ -662,6 +703,9 @@ class ElementHandler:
 
     def set_target_direction(self, direction):
         self.target_direction = direction
+
+    def set_source_lang(self, lang):
+        self.source_lang = lang
 
     def set_translation_lang(self, lang):
         self.translation_lang = lang
@@ -694,6 +738,7 @@ class ElementHandler:
             element.set_placeholder(self.placeholder)
             element.set_position(self.position)
             element.set_target_direction(self.target_direction)
+            element.set_source_lang(self.source_lang)
             element.set_translation_lang(self.translation_lang)
             element.set_original_color(self.original_color)
             element.set_translation_color(self.translation_color)
@@ -750,6 +795,7 @@ class ElementHandlerMerge(ElementHandler):
             element.set_placeholder(self.placeholder)
             element.set_position(self.position)
             element.set_target_direction(self.target_direction)
+            element.set_source_lang(self.source_lang)
             element.set_translation_lang(self.translation_lang)
             element.set_original_color(self.original_color)
             element.set_translation_color(self.translation_color)
@@ -836,24 +882,88 @@ def get_pgn_elements(path, encoding):
 
 
 def get_metadata_elements(metadata):
+    """Extract metadata elements for separate translation (not as paragraphs).
+
+    Metadata is translated individually and cached in info table, not paragraph table.
+    Each field is displayed separately in UI, not mixed with content paragraphs.
+
+    Extracts all 9 metadata fields:
+    - title (dc:title)
+    - creator (dc:creator)
+    - publisher (dc:publisher)
+    - series (calibre:series)
+    - author_sort (calibre:author_sort / opf:file-as)
+    - rights (dc:rights)
+    - subject (dc:subject)
+    - contributor (dc:contributor)
+    - description (dc:description)
+
+    Each field respects individual translation settings from config.
+    """
     config = get_config()
-    enable_translation = config.get(
-        'ebook_metadata.metadata_translation', False)
+    metadata_config = config.get('ebook_metadata') or {}
+
+    # Get individual field translation flags
+    translate_title = metadata_config.get('translate_title', False)
+    translate_creator = metadata_config.get('translate_creator', False)
+    translate_publisher = metadata_config.get('translate_publisher', False)
+    translate_series = metadata_config.get('translate_series', False)
+    translate_rights = metadata_config.get('translate_rights', False)
+    translate_subject = metadata_config.get('translate_subject', False)
+    translate_contributor = metadata_config.get('translate_contributor', False)
+    translate_description = metadata_config.get('translate_description', False)
+
+    # title_sort and author_sort follow their parent fields (no separate settings)
+    translate_title_sort = translate_title
+    translate_author_sort = translate_creator
+
+    # Backward compatibility: check old 'metadata_translation' key
+    old_translate_all = metadata_config.get('metadata_translation', False)
+    if old_translate_all and not any([translate_title, translate_creator, translate_publisher]):
+        # Migrate old setting: enable common fields
+        translate_title = translate_creator = translate_publisher = True
+
     elements = []
-    names = (
-        'title', 'creator', 'publisher', 'rights', 'subject', 'contributor',
-        'description')
+    # Include series, title_sort, and author_sort (Calibre-specific fields)
+    names = ('title', 'title_sort', 'creator', 'author_sort', 'publisher', 'series', 'rights', 'subject', 'contributor', 'description')
     pattern = re.compile(r'[a-zA-Z]+')
+
     for key in metadata.iterkeys():
         if key not in names:
             continue
         items = getattr(metadata, key)
+
+        # Determine if this field should be translated
+        should_translate = False
+        if key == 'title' and translate_title:
+            should_translate = True
+        elif key == 'creator' and translate_creator:
+            should_translate = True
+        elif key == 'publisher' and translate_publisher:
+            should_translate = True
+        elif key == 'series' and translate_series:
+            should_translate = True
+        elif key == 'title_sort' and translate_title_sort:
+            should_translate = True
+        elif key == 'author_sort' and translate_author_sort:
+            should_translate = True
+        elif key == 'rights' and (translate_rights or old_translate_all):
+            should_translate = True
+        elif key == 'subject' and (translate_subject or old_translate_all):
+            should_translate = True
+        elif key == 'contributor' and (translate_contributor or old_translate_all):
+            should_translate = True
+        elif key == 'description' and (translate_description or old_translate_all):
+            should_translate = True
+
         for item in items:
             if pattern.search(item.content) is None:
                 continue
+            # Store element reference for translation, but mark ignored for paragraph system
             element = MetadataElement(
-                item, page_id='content.opf', ignored=not enable_translation)
+                item, page_id='content.opf', ignored=not should_translate)
             elements.append(element)
+
     return elements
 
 

--- a/lib/translation.py
+++ b/lib/translation.py
@@ -155,9 +155,38 @@ class Translation:
     def translate_paragraph(self, paragraph):
         if self.cancel_request():
             raise TranslationCanceled(_('Translation canceled.'))
+
+        # For ignored metadata, just copy original to translation (don't translate)
+        is_metadata = paragraph.page == 'content.opf'
+        if is_metadata and paragraph.ignored:
+            paragraph.translation = paragraph.original
+            paragraph.engine_name = self.translator.name
+            paragraph.target_lang = self.translator.get_target_lang()
+            paragraph.is_cache = False
+            return
+
         if paragraph.translation and not self.fresh:
             paragraph.is_cache = True
+            # Log cache hits for metadata/TOC
+            from .config import get_config
+            if get_config().get('log_translation', True):
+                is_toc = paragraph.page == 'toc.ncx'
+                if is_metadata:
+                    log.info('[DEBUG] ✓ Metadata from cache: "%s"' % paragraph.original[:60])
+                elif is_toc:
+                    log.info('[DEBUG] ✓ TOC from cache: "%s"' % paragraph.original[:60])
             return
+
+        # Log cache misses for metadata/TOC
+        from .config import get_config
+        if get_config().get('log_translation', True):
+            is_metadata = paragraph.page == 'content.opf'
+            is_toc = paragraph.page == 'toc.ncx'
+            if is_metadata:
+                log.warn('[DEBUG] ✗ Metadata NOT in cache, translating now: "%s"' % paragraph.original[:60])
+            elif is_toc:
+                log.info('[DEBUG] ○ TOC not in cache, translating: "%s"' % paragraph.original[:60])
+
         self.streaming('')
         self.streaming(_('Translating...'))
         text = self.glossary.replace(paragraph.original)
@@ -169,6 +198,9 @@ class Translation:
                 temp = ''
                 clear = True
                 for char in translation:
+                    # Check for cancellation during streaming
+                    if self.cancel_request():
+                        raise TranslationCanceled(_('Translation canceled.'))
                     if clear:
                         self.streaming('')
                         clear = False
@@ -176,7 +208,13 @@ class Translation:
                     time.sleep(0.05)
                     temp += char
             else:
-                temp = ''.join([char for char in translation])
+                # For batch mode, still check cancellation periodically
+                temp_chars = []
+                for char in translation:
+                    if self.cancel_request():
+                        raise TranslationCanceled(_('Translation canceled.'))
+                    temp_chars.append(char)
+                temp = ''.join(temp_chars)
             translation = temp
         translation = self.glossary.restore(translation)
         paragraph.translation = translation.strip()
@@ -198,15 +236,18 @@ class Translation:
         row = paragraph.row
         original = paragraph.original.strip()
         if paragraph.error is None:
-            self.log(sep())
-            if row >= 0:
-                self.log(_('Row: {}').format(row))
-            self.log(_('Original: {}').format(original))
-            self.log(sep('┈'))
-            message = _('Translation: {}')
-            if paragraph.is_cache:
-                message = _('Translation (Cached): {}')
-            self.log(message.format(paragraph.translation.strip()))
+            # Only log verbose content if log_content setting is enabled
+            from .config import get_config
+            if get_config().get('log_content', True):
+                self.log(sep())
+                if row >= 0:
+                    self.log(_('Row: {}').format(row))
+                self.log(_('Original: {}').format(original))
+                self.log(sep('┈'))
+                message = _('Translation: {}')
+                if paragraph.is_cache:
+                    message = _('Translation (Cached): {}')
+                self.log(message.format(paragraph.translation.strip()))
 
     def handle(self, paragraphs=[]):
         start_time = time.time()
@@ -214,6 +255,15 @@ class Translation:
         for paragraph in paragraphs:
             self.total += 1
             char_count += len(paragraph.original)
+
+        # Set up prompt caching if enabled
+        # Collect full book context for caching (Claude only)
+        if hasattr(self.translator, 'enable_prompt_caching') and self.translator.enable_prompt_caching:
+            full_context = '\n\n'.join([p.original for p in paragraphs])
+            self.translator.full_book_context = full_context
+            self.log(sep())
+            self.log(_('Prompt caching enabled - using full book context'))
+            self.log(_('Context size: {} characters').format(len(full_context)))
 
         self.log(sep())
         self.log(_('Start to translate ebook content'))

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -69,6 +69,27 @@ def uid(*args):
     return md5.hexdigest()
 
 
+def get_cache_id(input_path, engine_name, target_lang, merge_length, encoding='utf-8'):
+    """Calculate cache ID consistently across codebase.
+
+    Cache ID is based on: input file + engine + target language + merge length + encoding.
+    This ensures separate caches for different translation configurations.
+
+    Args:
+        input_path: Path to input ebook file
+        engine_name: Translation engine name (e.g., 'Claude', 'ChatGPT')
+        target_lang: Target language display name (e.g., 'Hebrew', 'Spanish')
+        merge_length: Merge length value (int or str)
+        encoding: File encoding (default: 'utf-8')
+
+    Returns:
+        Cache ID string (MD5 hash)
+    """
+    merge_length_str = str(merge_length)
+    encoding_suffix = '' if encoding.lower() == 'utf-8' else encoding.lower()
+    return uid(input_path + engine_name + target_lang + merge_length_str + encoding_suffix)
+
+
 def trim(text):
     # Replace \xa0 with whitespace to be compatible with Python 2.x.
     text = re.sub(u'\u00a0|\u3000', ' ', text)

--- a/setting.py
+++ b/setting.py
@@ -18,6 +18,7 @@ from .lib.utils import (
 from .lib.translation import get_engine_class, get_translator
 from .engines import (
     builtin_engines, GeminiTranslate, ChatgptTranslate, AzureChatgptTranslate)
+from .engines.anthropic import ClaudeTranslate
 from .engines.genai import GenAI
 from .engines.custom import CustomTranslate
 from .components import (
@@ -242,15 +243,27 @@ class TranslationSetting(QDialog):
         # Merge Translate
         merge_group = QGroupBox(
             '%s %s' % (_('Merge to Translate'), _('(Beta)')))
-        merge_layout = QHBoxLayout(merge_group)
+        merge_layout = QVBoxLayout(merge_group)
+
+        # First row: controls
+        merge_controls = QWidget()
+        merge_controls_layout = QHBoxLayout(merge_controls)
+        merge_controls_layout.setContentsMargins(0, 0, 0, 0)
         merge_enabled = QCheckBox(_('Enable'))
         self.merge_length = QSpinBox()
         self.merge_length.setRange(1, 999999)
-        merge_layout.addWidget(merge_enabled)
-        merge_layout.addWidget(self.merge_length)
-        merge_layout.addWidget(QLabel(_(
+        merge_controls_layout.addWidget(merge_enabled)
+        merge_controls_layout.addWidget(self.merge_length)
+        merge_controls_layout.addWidget(QLabel(_(
             'The number of characters to translate at once.')))
-        merge_layout.addStretch(1)
+        merge_controls_layout.addStretch(1)
+        merge_layout.addWidget(merge_controls)
+
+        # Second row: Token estimate helper (Claude only)
+        self.merge_token_estimate = QLabel()
+        self.merge_token_estimate.setVisible(False)
+        merge_layout.addWidget(self.merge_token_estimate)
+
         layout.addWidget(merge_group)
 
         self.disable_wheel_event(self.merge_length)
@@ -259,6 +272,9 @@ class TranslationSetting(QDialog):
         merge_enabled.setChecked(self.config.get('merge_enabled'))
         merge_enabled.clicked.connect(
             lambda checked: self.config.update(merge_enabled=checked))
+        self.merge_length.valueChanged.connect(
+            lambda: self.update_merge_token_estimate())
+        # Note: source_lang connection added later after widget is created
 
         # Network Proxy
         proxy_group = QGroupBox(_('Network Proxy'))
@@ -357,8 +373,14 @@ class TranslationSetting(QDialog):
         # Job Log
         log_group = QGroupBox(_('Job Log'))
         log_translation = QCheckBox(_('Show translation'))
+        log_content = QCheckBox(_('Show original/translated content'))
+        log_content.setToolTip(_(
+            'Show the full original and translated text for each paragraph in the log.\n'
+            'Disable to reduce log verbosity.\n'
+            'Default: ON'))
         log_layout = QVBoxLayout(log_group)
         log_layout.addWidget(log_translation)
+        log_layout.addWidget(log_content)
         log_layout.addStretch(1)
         misc_layout.addWidget(log_group, 1)
 
@@ -374,6 +396,10 @@ class TranslationSetting(QDialog):
         log_translation.setChecked(self.config.get('log_translation', True))
         log_translation.toggled.connect(
             lambda checked: self.config.update(log_translation=checked))
+
+        log_content.setChecked(self.config.get('log_content', True))
+        log_content.toggled.connect(
+            lambda checked: self.config.update(log_content=checked))
 
         notice.setChecked(self.config.get('show_notification', True))
         notice.toggled.connect(
@@ -452,6 +478,10 @@ class TranslationSetting(QDialog):
         language_layout.addRow(_('Source Language'), self.source_lang)
         language_layout.addRow(_('Target Language'), self.target_lang)
         layout.addWidget(language_group)
+
+        # Connect source language changes to token estimate update
+        self.source_lang.currentTextChanged.connect(
+            lambda: self.update_merge_token_estimate())
 
         self.apply_form_layout_policy(language_layout)
 
@@ -557,6 +587,35 @@ class TranslationSetting(QDialog):
         stream_enabled = QCheckBox(_('Enable streaming response'))
         genai_layout.addRow(_('Stream'), stream_enabled)
 
+        # Claude-specific beta features - store as instance variables for access in methods
+        extended_output_label = QLabel(_('Extended Output'))
+        self.extended_output_enabled = QCheckBox(_(
+            'Enable 128K output tokens'))
+        extended_output_label.setVisible(False)
+        self.extended_output_enabled.setVisible(False)
+        genai_layout.addRow(extended_output_label, self.extended_output_enabled)
+
+        extended_context_label = QLabel(_('Extended Context'))
+        self.extended_context_enabled = QCheckBox(_(
+            'Enable 1M context window'))
+        extended_context_label.setVisible(False)
+        self.extended_context_enabled.setVisible(False)
+        genai_layout.addRow(extended_context_label, self.extended_context_enabled)
+
+        dynamic_timeout_label = QLabel(_('Dynamic Timeout'))
+        dynamic_timeout_enabled = QCheckBox(_(
+            'Scale timeout based on content length (for large merges)'))
+        dynamic_timeout_label.setVisible(False)
+        dynamic_timeout_enabled.setVisible(False)
+        genai_layout.addRow(dynamic_timeout_label, dynamic_timeout_enabled)
+
+        prompt_caching_label = QLabel(_('Prompt Caching'))
+        prompt_caching_enabled = QCheckBox(_(
+            'Enable parallel sections with full book context (90% cheaper input)'))
+        prompt_caching_label.setVisible(False)
+        prompt_caching_enabled.setVisible(False)
+        genai_layout.addRow(prompt_caching_label, prompt_caching_enabled)
+
         sampling_btn_group = QButtonGroup(sampling_widget)
         sampling_btn_group.addButton(temperature, 0)
         sampling_btn_group.addButton(top_p, 1)
@@ -570,6 +629,49 @@ class TranslationSetting(QDialog):
             .update(sampling=labels[button]))
 
         layout.addWidget(genai_group)
+
+        # Update Claude beta feature visibility based on selected model
+        def update_claude_beta_features():
+            if not issubclass(self.current_engine, ClaudeTranslate):
+                extended_output_label.setVisible(False)
+                self.extended_output_enabled.setVisible(False)
+                extended_context_label.setVisible(False)
+                self.extended_context_enabled.setVisible(False)
+                return
+
+            # Get the current model
+            model = None
+            if genai_model_input.isVisible():
+                model = genai_model_input.text().strip()
+            else:
+                model = genai_model_list.currentText()
+
+            if not model or model == _('Custom'):
+                # If no model selected or Custom without text, hide both
+                extended_output_label.setVisible(False)
+                self.extended_output_enabled.setVisible(False)
+                extended_context_label.setVisible(False)
+                self.extended_context_enabled.setVisible(False)
+                return
+
+            # Show extended output for Claude 3.7 Sonnet models
+            if model.startswith('claude-3-7-sonnet-'):
+                extended_output_label.setVisible(True)
+                self.extended_output_enabled.setVisible(True)
+                extended_context_label.setVisible(False)
+                self.extended_context_enabled.setVisible(False)
+            # Show extended context for Claude Sonnet 4.0/4.5 models
+            elif model.startswith('claude-sonnet-4-0') or model.startswith('claude-sonnet-4-5'):
+                extended_output_label.setVisible(False)
+                self.extended_output_enabled.setVisible(False)
+                extended_context_label.setVisible(True)
+                self.extended_context_enabled.setVisible(True)
+            else:
+                # Hide both for other models
+                extended_output_label.setVisible(False)
+                self.extended_output_enabled.setVisible(False)
+                extended_context_label.setVisible(False)
+                self.extended_context_enabled.setVisible(False)
 
         # Setup genAI model
         def init_ai_models(model=None):
@@ -602,10 +704,15 @@ class TranslationSetting(QDialog):
                 if model in models or model == _('Custom'):
                     genai_model_input.clear()
             genai_model_list.currentTextChanged.connect(init_ai_models)
+            # Update Claude beta features visibility after model change
+            update_claude_beta_features()
         self.model_worker.finished.connect(init_ai_models)
-        genai_model_input.textChanged.connect(
-            lambda model: self.current_engine.config.update(
-                model=model.strip()))
+
+        def on_custom_model_changed(model):
+            self.current_engine.config.update(model=model.strip())
+            update_claude_beta_features()
+
+        genai_model_input.textChanged.connect(on_custom_model_changed)
 
         def fetch_ai_models():
             try:
@@ -703,6 +810,59 @@ class TranslationSetting(QDialog):
                 config.get('stream', self.current_engine.stream))
             stream_enabled.toggled.connect(
                 lambda checked: config.update(stream=checked))
+
+            # Claude-specific features
+            # Hide by default, will be shown based on model selection
+            extended_output_label.setVisible(False)
+            self.extended_output_enabled.setVisible(False)
+            extended_context_label.setVisible(False)
+            self.extended_context_enabled.setVisible(False)
+            dynamic_timeout_label.setVisible(False)
+            dynamic_timeout_enabled.setVisible(False)
+            prompt_caching_label.setVisible(False)
+            prompt_caching_enabled.setVisible(False)
+
+            if issubclass(self.current_engine, ClaudeTranslate):
+                # Load configuration values
+                self.extended_output_enabled.setChecked(
+                    config.get('enable_extended_output',
+                               self.current_engine.enable_extended_output))
+                self.extended_context_enabled.setChecked(
+                    config.get('enable_extended_context',
+                               self.current_engine.enable_extended_context))
+                dynamic_timeout_enabled.setChecked(
+                    config.get('enable_dynamic_timeout',
+                               self.current_engine.enable_dynamic_timeout))
+                prompt_caching_enabled.setChecked(
+                    config.get('enable_prompt_caching',
+                               self.current_engine.enable_prompt_caching))
+
+                # Show options for all Claude models
+                dynamic_timeout_label.setVisible(True)
+                dynamic_timeout_enabled.setVisible(True)
+                prompt_caching_label.setVisible(True)
+                prompt_caching_enabled.setVisible(True)
+
+                # Connect to config updates
+                try:
+                    self.extended_output_enabled.toggled.disconnect()
+                    self.extended_context_enabled.toggled.disconnect()
+                    dynamic_timeout_enabled.toggled.disconnect()
+                    prompt_caching_enabled.toggled.disconnect()
+                except TypeError:
+                    pass
+                self.extended_output_enabled.toggled.connect(
+                    lambda checked: config.update(enable_extended_output=checked))
+                self.extended_context_enabled.toggled.connect(
+                    lambda checked: config.update(enable_extended_context=checked))
+                dynamic_timeout_enabled.toggled.connect(
+                    lambda checked: config.update(enable_dynamic_timeout=checked))
+                prompt_caching_enabled.toggled.connect(
+                    lambda checked: config.update(enable_prompt_caching=checked))
+                # Update token estimate when context setting changes
+                self.extended_context_enabled.toggled.connect(
+                    lambda: self.update_merge_token_estimate())
+
             genai_group.setVisible(True)
 
         def choose_default_engine(index):
@@ -763,6 +923,8 @@ class TranslationSetting(QDialog):
             if issubclass(self.current_engine, GenAI):
                 genai_group.setVisible(True)
                 show_genai_preferences(config)
+            # Update merge token estimate when engine changes
+            self.update_merge_token_estimate()
         choose_default_engine(engine_list.findData(self.current_engine.name))
         engine_list.currentIndexChanged.connect(choose_default_engine)
 
@@ -1183,30 +1345,72 @@ class TranslationSetting(QDialog):
         metadata_group = QGroupBox(_('Ebook Metadata'))
         metadata_layout = QFormLayout(metadata_group)
         self.apply_form_layout_policy(metadata_layout)
-        self.metadata_translation = QCheckBox(
-            _('Translate all of the metadata information'))
+
+        # Individual metadata field translation checkboxes
+        # Primary fields (most commonly used)
+        self.metadata_translate_title = QCheckBox(
+            _('Title (used if custom title not provided)'))
+        self.metadata_translate_creator = QCheckBox(_('Creator (author)'))
+        self.metadata_translate_publisher = QCheckBox(_('Publisher'))
+        self.metadata_translate_series = QCheckBox(_('Series name'))
+
+        # Advanced fields (less commonly used)
+        self.metadata_translate_creator_file_as = QCheckBox(_('Creator file-as (author sort)'))
+        self.metadata_translate_rights = QCheckBox(_('Rights (copyright)'))
+        self.metadata_translate_subject = QCheckBox(_('Subject (keywords)'))
+        self.metadata_translate_contributor = QCheckBox(_('Contributors (editors, etc.)'))
+        self.metadata_translate_description = QCheckBox(_('Description'))
+
         self.metadata_lang_mark = QCheckBox(
             _('Append target language to title metadata'))
         self.metadata_lang_code = QCheckBox(
             _('Set target language code to language metadata'))
-        self.metadata_subject = QPlainTextEdit()
-        self.metadata_subject.setPlaceholderText(
+        self.metadata_subjects = QPlainTextEdit()
+        self.metadata_subjects.setPlaceholderText(
             _('Subjects of ebook (one subject per line)'))
-        metadata_layout.addRow(
-            _('Metadata Translation'), self.metadata_translation)
-        metadata_layout.addRow(_('Language Mark'), self.metadata_lang_mark)
+
+        metadata_layout.addRow(_('Translate Fields:'), QLabel(''))
+        metadata_layout.addRow('', self.metadata_translate_title)
+        metadata_layout.addRow('', self.metadata_translate_creator)
+        metadata_layout.addRow('', self.metadata_translate_publisher)
+        metadata_layout.addRow('', self.metadata_translate_series)
+        metadata_layout.addRow(_('Advanced Fields:'), QLabel(''))
+        metadata_layout.addRow('', self.metadata_translate_creator_file_as)
+        metadata_layout.addRow('', self.metadata_translate_rights)
+        metadata_layout.addRow('', self.metadata_translate_subject)
+        metadata_layout.addRow('', self.metadata_translate_contributor)
+        metadata_layout.addRow('', self.metadata_translate_description)
         metadata_layout.addRow(_('Language Code'), self.metadata_lang_code)
-        metadata_layout.addRow(_('Append Subjects'), self.metadata_subject)
+        metadata_layout.addRow(_('Language Mark'), self.metadata_lang_mark)
+        metadata_layout.addRow(_('Append Subjects'), self.metadata_subjects)
         layout.addWidget(metadata_group)
 
-        self.metadata_translation.setChecked(
-            self.config.get('ebook_metadata.metadata_translation', False))
+        # Migration happens automatically on plugin load (lib/config.py ver241_upgrade)
+        # Load configuration
+        self.metadata_translate_title.setChecked(
+            self.config.get('ebook_metadata.translate_title', True))
+        self.metadata_translate_creator.setChecked(
+            self.config.get('ebook_metadata.translate_creator', False))
+        self.metadata_translate_creator_file_as.setChecked(
+            self.config.get('ebook_metadata.translate_creator_file_as', False))
+        self.metadata_translate_publisher.setChecked(
+            self.config.get('ebook_metadata.translate_publisher', False))
+        self.metadata_translate_series.setChecked(
+            self.config.get('ebook_metadata.translate_series', False))
+        self.metadata_translate_rights.setChecked(
+            self.config.get('ebook_metadata.translate_rights', False))
+        self.metadata_translate_subject.setChecked(
+            self.config.get('ebook_metadata.translate_subject', False))
+        self.metadata_translate_contributor.setChecked(
+            self.config.get('ebook_metadata.translate_contributor', False))
+        self.metadata_translate_description.setChecked(
+            self.config.get('ebook_metadata.translate_description', False))
+
         self.metadata_lang_mark.setChecked(
             self.config.get('ebook_metadata.lang_mark', False))
         self.metadata_lang_code.setChecked(self.config.get(
-            'ebook_metadata.lang_code',
-            self.config.get('ebook_metadata.language', False)))  # old key
-        self.metadata_subject.setPlainText(
+            'ebook_metadata.lang_code', True))  # Changed default to True
+        self.metadata_subjects.setPlainText(
             '\n'.join(self.config.get('ebook_metadata.subjects') or []))
 
         layout.addStretch(1)
@@ -1434,11 +1638,20 @@ class TranslationSetting(QDialog):
         ebook_metadata = self.config.get('ebook_metadata') or {}
         ebook_metadata = ebook_metadata.copy()
         ebook_metadata.clear()
-        ebook_metadata.update(
-            metadata_translation=self.metadata_translation.isChecked())
+        # Individual field translation flags
+        # Save all 9 metadata translation flags
+        ebook_metadata.update(translate_title=self.metadata_translate_title.isChecked())
+        ebook_metadata.update(translate_creator=self.metadata_translate_creator.isChecked())
+        ebook_metadata.update(translate_creator_file_as=self.metadata_translate_creator_file_as.isChecked())
+        ebook_metadata.update(translate_publisher=self.metadata_translate_publisher.isChecked())
+        ebook_metadata.update(translate_series=self.metadata_translate_series.isChecked())
+        ebook_metadata.update(translate_rights=self.metadata_translate_rights.isChecked())
+        ebook_metadata.update(translate_subject=self.metadata_translate_subject.isChecked())
+        ebook_metadata.update(translate_contributor=self.metadata_translate_contributor.isChecked())
+        ebook_metadata.update(translate_description=self.metadata_translate_description.isChecked())
         ebook_metadata.update(lang_mark=self.metadata_lang_mark.isChecked())
         ebook_metadata.update(lang_code=self.metadata_lang_code.isChecked())
-        subject_content = self.metadata_subject.toPlainText().strip()
+        subject_content = self.metadata_subjects.toPlainText().strip()
         if subject_content:
             subjects = [s.strip() for s in subject_content.split('\n')]
             ebook_metadata.update(subjects=subjects)
@@ -1459,6 +1672,96 @@ class TranslationSetting(QDialog):
         layout.setFieldGrowthPolicy(
             QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow)
         layout.setLabelAlignment(Qt.AlignRight)
+
+    def update_merge_token_estimate(self):
+        """Update token estimate for Claude merge translation feature."""
+        if not issubclass(self.current_engine, ClaudeTranslate):
+            self.merge_token_estimate.setVisible(False)
+            return
+
+        chars = self.merge_length.value()
+
+        # Get current source language from widget (not config, for real-time updates)
+        source_lang_name = self.source_lang.currentText()
+        if source_lang_name == _('Auto detect'):
+            source_lang_code = 'auto'
+        else:
+            # Look up language code from display name
+            lang_codes = self.current_engine.lang_codes.get('source', {})
+            source_lang_code = lang_codes.get(source_lang_name, 'auto')
+
+        # Character-to-token ratios by language family
+        # Based on Claude tokenizer characteristics
+        if source_lang_code in ['zh-CN', 'zh-TW', 'ja', 'ko']:
+            # CJK languages: ~1.5 chars per token
+            chars_per_token = 1.5
+            lang_note = 'CJK'
+        elif source_lang_code in ['ar', 'he', 'iw']:
+            # Arabic/Hebrew: ~3 chars per token (iw is legacy code for Hebrew)
+            chars_per_token = 3
+            lang_note = 'Arabic/Hebrew'
+        else:
+            # English and most Western languages: ~4 chars per token
+            chars_per_token = 4
+            lang_note = source_lang_name if source_lang_code != 'auto' else 'Western languages'
+
+        tokens = int(chars / chars_per_token)
+
+        # Determine context window size based on model and settings
+        model = self.current_engine.config.get('model', self.current_engine.model)
+
+        # Model-specific context windows (in tokens)
+        # Note: This cannot be fetched from the API - the /v1/models endpoint
+        # only returns id, display_name, created_at, and type fields.
+        # Source: https://platform.claude.com/docs/en/about-claude/models/overview
+        model_context_windows = {
+            # Claude 4.5 models (current)
+            'claude-sonnet-4-5': 200_000,    # 1M with beta flag
+            'claude-haiku-4-5': 200_000,
+            'claude-opus-4-5': 200_000,
+            # Claude 4.x legacy models
+            'claude-opus-4-1': 200_000,
+            'claude-sonnet-4-0': 200_000,    # 1M with beta flag
+            'claude-opus-4-0': 200_000,
+            # Claude 3.x models
+            'claude-3-7-sonnet': 200_000,
+            'claude-3-5-sonnet': 200_000,
+            'claude-3-5-haiku': 200_000,
+            'claude-3-opus': 200_000,
+            'claude-3-sonnet': 200_000,
+            'claude-3-haiku': 200_000,
+        }
+
+        # Find matching model prefix
+        context_window = None
+        model_matched = False
+        if model:
+            for model_prefix, window_size in model_context_windows.items():
+                if model.startswith(model_prefix):
+                    context_window = window_size
+                    model_matched = True
+                    break
+
+        # Fallback to default if model not recognized
+        if context_window is None:
+            context_window = 200_000
+            model_matched = False
+
+        # Apply extended context if enabled for supported models
+        if model and (model.startswith('claude-sonnet-4-0') or model.startswith('claude-sonnet-4-5')) \
+                and self.extended_context_enabled.isChecked():
+            context_window = 1_000_000
+
+        context_pct = (tokens / context_window) * 100
+        context_label = f'{context_window // 1000}K' if context_window < 1_000_000 else '1M'
+
+        # Add note if using default context window
+        default_note = _(' (estimated default)') if not model_matched else ''
+
+        estimate_text = _('Estimated: ~{} tokens for {} (~{:.2f}% of {} context{})').format(
+            f'{tokens:,}', lang_note, context_pct, context_label, default_note)
+        self.merge_token_estimate.setText(estimate_text)
+        self.merge_token_estimate.setVisible(True)
 
     def done(self, result):
         self.model_thread.quit()

--- a/tests/lib/test_config.py
+++ b/tests/lib/test_config.py
@@ -23,6 +23,7 @@ class TestFunction(unittest.TestCase):
             'cache_enabled': True,
             'cache_path': None,
             'log_translation': True,
+            'log_content': True,
             'show_notification': True,
             'translation_position': None,
             'column_gap': {

--- a/tests/lib/test_conversion.py
+++ b/tests/lib/test_conversion.py
@@ -19,9 +19,12 @@ class TestConversionWorker(unittest.TestCase):
         self.worker.api = Mock()
 
         self.ebook = Mock(Ebook)
+        self.ebook.output_format = 'epub'
+        self.ebook.source_lang = 'English'
+        self.ebook.target_direction = None
         self.job = Mock()
         self.worker.working_jobs = {
-            self.job: (self.ebook, str(Path('/path/to/test.epub')))}
+            self.job: (self.ebook, str(Path('/path/to/test.epub')), False)}
 
     def test_create_worker(self):
         self.assertIsInstance(self.worker, ConversionWorker)
@@ -38,12 +41,13 @@ class TestConversionWorker(unittest.TestCase):
             self.gui.job_exception.assert_called_once_with(
                 self.job, dialog_title='Translation job failed')
 
+    @patch(module_name + '.get_translator')
     @patch(module_name + '.os')
     @patch(module_name + '.open')
     @patch(module_name + '.get_metadata')
     @patch(module_name + '.set_metadata')
     def test_translate_done_ebook_to_library(
-            self, mock_set_metadata, mock_get_metadata, mock_open, mock_os):
+            self, mock_set_metadata, mock_get_metadata, mock_open, mock_os, mock_get_translator):
         self.job.failed = False
         self.job.description = 'test description'
         self.job.log_path = '/path/to/log'
@@ -70,6 +74,11 @@ class TestConversionWorker(unittest.TestCase):
         metadata.tags = []
         metadata.language = 'en'
         mock_get_metadata.return_value = metadata
+
+        # Mock translator for RTL/LTR handling
+        mock_translator = Mock()
+        mock_translator.get_source_code.return_value = 'en'
+        mock_get_translator.return_value = mock_translator
 
         self.worker.db.create_book_entry.return_value = 89
         self.worker.api.format_abspath.return_value = '/path/to/test[m].epub'
@@ -118,6 +127,7 @@ class TestConversionWorker(unittest.TestCase):
         self.assertIs(self.icon, arguments.get('icon'))
 
 
+    @patch(module_name + '.get_translator')
     @patch(module_name + '.open')
     @patch(module_name + '.open_path')
     @patch(module_name + '.os.rename')
@@ -125,7 +135,7 @@ class TestConversionWorker(unittest.TestCase):
     @patch(module_name + '.set_metadata')
     def test_translate_done_ebook_to_path(
             self, mock_set_metadata, mock_get_metadata, mock_os_rename,
-            mock_open_path, mock_open):
+            mock_open_path, mock_open, mock_get_translator):
         self.job.failed = False
         self.job.description = 'test description'
         self.job.log_path = str(Path('/path/to/log'))
@@ -152,6 +162,11 @@ class TestConversionWorker(unittest.TestCase):
         metadata.tags = []
         metadata.language = 'en'
         mock_get_metadata.return_value = metadata
+
+        # Mock translator for RTL/LTR handling
+        mock_translator = Mock()
+        mock_translator.get_source_code.return_value = 'en'
+        mock_get_translator.return_value = mock_translator
 
         self.worker.translate_done(self.job)
 
@@ -207,7 +222,7 @@ class TestConversionWorker(unittest.TestCase):
         self.ebook.custom_title = 'test custom title'
         self.ebook.target_lang = 'German'
         self.worker.working_jobs = {
-            self.job: (self.ebook, str(Path('/path/to/test.srt')))}
+            self.job: (self.ebook, str(Path('/path/to/test.srt')), False)}
         metadata = Mock()
         self.worker.api.get_metadata.return_value = metadata
         self.worker.api.format_abspath.return_value = \
@@ -270,7 +285,7 @@ class TestConversionWorker(unittest.TestCase):
         self.ebook.custom_title = 'test: custom title*'
         self.ebook.target_lang = 'German'
         self.worker.working_jobs = {
-            self.job: (self.ebook, str(Path('/path/to/test.srt')))}
+            self.job: (self.ebook, str(Path('/path/to/test.srt')), False)}
         metadata = Mock()
         self.worker.api.get_metadata.return_value = metadata
 

--- a/tests/lib/test_element.py
+++ b/tests/lib/test_element.py
@@ -73,7 +73,14 @@ class TestFunction(unittest.TestCase):
 
     @patch(module_name + '.get_config')
     def test_get_metadata_elements(self, mock_get_config):
-        mock_get_config.return_value.get.return_value = False
+        # Mock config to enable translation for title and subject
+        mock_config = Mock()
+        mock_config.get.return_value = {
+            'translate_title': True,
+            'translate_subject': True,
+        }
+        mock_get_config.return_value = mock_config
+
         metadata = Mock(Metadata)
         item_1 = Mock(Metadata.Item, content='a')
         item_2 = Mock(Metadata.Item, content='b')
@@ -85,13 +92,15 @@ class TestFunction(unittest.TestCase):
 
         elements = get_metadata_elements(metadata)
 
-        mock_get_config().get.assert_called_once_with(
-            'ebook_metadata.metadata_translation', False)
+        # Metadata elements extracted for separate translation (not as paragraphs)
+        # They're marked as ignored for paragraph system but translated separately
+        mock_get_config.assert_called_once()
+        mock_config.get.assert_called_with('ebook_metadata')
         self.assertEqual(2, len(elements))
         self.assertIs(item_1, elements[0].element)
-        self.assertTrue(elements[0].ignored)
+        self.assertFalse(elements[0].ignored)  # Should be translatable (via separate system)
         self.assertIs(item_2, elements[1].element)
-        self.assertTrue(elements[1].ignored)
+        self.assertFalse(elements[1].ignored)  # Should be translatable (via separate system)
 
 
 class MockedElement(Element):


### PR DESCRIPTION
## Summary

Complete rewrite of metadata and TOC translation system with separate caching, individual field control, and integrated Advanced Mode UI display.

### Metadata Translation System

**Individual Field Translation**
- 9 metadata fields with granular control: title, creator, publisher, series, rights, subject, contributor, description
- Each field stored separately in cache (not merged with content)
- Only enabled fields appear in cache and UI
- Auto-populate title_sort from translated title
- Auto-populate author_sort from translated creator

**Cache Storage**
- Metadata stored with page='content.opf' for identification
- Separate from content paragraphs (page=None or specific page)
- Individual cache entries allow selective editing
- Backward compatible with old caches

**Smart Sort Field Handling**
- title_sort follows translate_title setting (no separate checkbox)
- author_sort follows translate_creator setting
- Auto-populated only if not present as separate field
- Uses custom_title in output phase if provided

### TOC Translation

**Merged Translation**
- All TOC entries merged into single paragraph for efficient translation
- Stored with page='toc.ncx' identifier
- Translate as one unit with \n\n separator
- Split back to individual TOC elements after translation
- Single row in Advanced Mode UI

### Cache Synchronization

**Automatic Migration**
- Detect old cache structure (pre-separate metadata)
- Add missing metadata/TOC entries to existing caches
- Remove obsolete entries when structure changes
- Log migrations: [CACHE SYNC] Added metadata [title]: "..."

**Cache ID Refactoring**
- Extract get_cache_id() helper function
- Consistent across convert_item, translate_done, PreparationWorker
- Single source of truth prevents cache mismatches

### Advanced Mode UI

**Type Column**
- New first column showing entry type
- "Metadata" for metadata fields
- "TOC" for table of contents
- Empty for content paragraphs

**Metadata Display**
- Metadata rows appear before translation (immediately on cache creation)
- Show original values from ebook
- Show cached translations if available
- Separate from content for clarity

**Smart Behavior**
- Alignment checks skip metadata/TOC (content only)
- Delete works correctly for metadata rows
- Translate All/Selected handles all types

### Settings

**Log Content Toggle**
- New checkbox: "Show original/translated content"
- Controls verbose paragraph text display
- Independent of "Show translation" setting
- Default: ON (current behavior)

**Simplified Metadata Settings**
- Removed translate_creator_file_as checkbox
- Removed translate_missing_metadata setting
- author_sort/title_sort now follow parent field settings

### Preparation Worker

**Extract All Elements**
- Metadata extraction during preparation (not just translation)
- TOC merged during preparation
- Consistent with convert_book logic
- UI populated immediately

## Testing

✅ Metadata fields stored separately in cache
✅ TOC merged into single entry  
✅ Advanced Mode shows Type column correctly
✅ Old caches upgraded automatically
✅ title_sort/author_sort auto-populated
✅ Cache delete works for non-consecutive rows

## Compatibility

- Works with fresh caches (new translations)
- Works with existing caches (auto-sync)
- Backward compatible metadata_translation config
- No breaking changes to existing workflows