### PR TITLE
feat: support custom placeholder by config for Custom Engine

### DIFF
--- a/engines/custom.py
+++ b/engines/custom.py
@@ -109,6 +109,13 @@ class CustomTranslate(Base):
         cls.response = data.get('response')
         cls.lang_codes = cls.load_lang_codes(data.get('languages'))
 
+        # If glossary_config is provided, replace the default placeholder
+        glossary_config = data.get('glossary_config') or {}
+        placeholder_pattern = glossary_config.get('placeholder_pattern')
+        match_pattern = glossary_config.get('match_pattern')
+        if placeholder_pattern and match_pattern:
+            cls.placeholder = (placeholder_pattern, match_pattern)
+
     def __init__(self):
         super().__init__()
         self.endpoint = self.request.get('url') or ''

--- a/tests/lib/test_engine.py
+++ b/tests/lib/test_engine.py
@@ -1141,9 +1141,47 @@ class TestCustom(unittest.TestCase):
     },
     "response": "response['text']"
 }"""
+        self.engine_data = json.loads(engine_data)
+        CustomTranslate.set_engine_data(self.engine_data)
 
-        engine_data = json.loads(engine_data)
-        CustomTranslate.set_engine_data(engine_data)
+    def test_custom_placeholder_creation(self):
+        original_engine_data = self.engine_data.copy()
+
+        # Verify default placeholder
+        default_placeholder = ('{{{{id_{}}}}}', r'({{\s*)+id\s*_\s*{}\s*(\s*}})+')
+        self.assertEqual(default_placeholder, CustomTranslate.placeholder)
+
+        # Incomplete glossary_config should not change the placeholder
+        incomplete_config = r"""{
+            "glossary_config": {
+                "placeholder_pattern": "//id_{}//"
+            }
+        }"""
+        CustomTranslate.set_engine_data(original_engine_data | json.loads(incomplete_config))
+        self.assertEqual(default_placeholder, CustomTranslate.placeholder)
+
+        # Incorrect glossary_config should not change the placeholder
+        incorrect_config = r"""{
+            "glossary_config": {
+                "wrong_key": "//id_{}//",
+                "match_pattern": "(//\\s*)+id\\s*_\\s*{}\\s*(\\s*//)+"
+            }
+        }"""
+        CustomTranslate.set_engine_data(original_engine_data | json.loads(incorrect_config))
+        self.assertEqual(default_placeholder, CustomTranslate.placeholder)
+
+        correct_config = r"""{
+            "glossary_config": {
+                "placeholder_pattern": "//id_{}//",
+                "match_pattern": "(//\\s*)+id\\s*_\\s*{}\\s*(\\s*//)+"
+            }
+        }"""
+        CustomTranslate.set_engine_data(original_engine_data | json.loads(correct_config))
+        custom_placeholder = ('//id_{}//', r'(//\s*)+id\s*_\s*{}\s*(\s*//)+')
+        self.assertEqual(custom_placeholder, CustomTranslate.placeholder)
+
+        # Restore original engine data because set_engine_data is class-wide
+        CustomTranslate.set_engine_data(original_engine_data)
 
     @patch(module_name + '.base.request')
     def test_translate(self, mock_request):


### PR DESCRIPTION
## Description

這個 PR 試著讓 custom engine 的 json config 加一組屬性，使其可以修改 placeholder 的 pattern

```json
{
    "name": "New Engine",
    "languages": {
        .....
    },
    "glossary_config": {
        "placeholder_pattern": "//id_{}//",
        "match_pattern": "(//\\s*)+id\\s*_\\s*{}\\s*(\\s*//)+"
    },
    ....
}
```

如果 config 裡面沒有完整同時提供 `glossary_config.placeholder_pattern` 與 `glossary_config.match_pattern`，則行為不變，繼續使用預設的 placeholder。

## Issue to be addressed

我使用 ollama 在 local 端跑 Sakura-14B-Qwen2.5-v1.0 翻譯的時候，開啟 Translation Glossary，並且準備了字典檔案

```
ゴジラ
哥吉拉
```

翻譯的結果卻如下圖

<img width="673" height="208" alt="translation_failed" src="https://github.com/user-attachments/assets/766eee2e-5273-4e7e-b153-c4f5a21f8af5" />

在 [translation.py](https://github.com/bookfere/Ebook-Translator-Calibre-Plugin/blob/2232a7932ad51060611ae485c7d3fd17016dbef0/lib/translation.py#L155) 加上 local change 印出一些 debug 訊息之後看到的是這樣

```
TRANSLATE ORIGINAL: ゴジラは可愛いじゃないか
GLOSSARY REPLACED: {{id_000000}}は可愛いじゃないか
TRANSLATE RESULT:【id_000000】不是很可爱吗
RESTORED RESULT:【id_000000】不是很可爱吗
```

我的理解是，Ebook-Translator 正確地把 `ゴジラ` 換成了 `{{id_000000}}`。然而模型翻譯時無法正確地辨識出這個模式，還多事地換成了「【】」(有些時候甚至換成了【诗织】這樣的超譯)，以致於 Restore glossary 的時候失敗了。

根據使用的模型不同，這部分的行為也會改變。我認為若能修改 placeholder pattern，應該可以舒緩這種情況：讓 User 能夠針對模型去調整 pattern。

我用上面的 `glossary_config` 來測試，將 `{{id_000000}}` 換成了 `//id_000000//`，看起來剛好可以避開模型的超譯

<img width="675" height="176" alt="translation_succeed" src="https://github.com/user-attachments/assets/e9f4abbc-52b3-4858-b5ca-406b40aae55b" />

```
TRANSLATE ORIGINAL: ゴジラは可愛いじゃないか
GLOSSARY REPLACED: //id_000000//は可愛いじゃないか
TRANSLATE RESULT: //id_000000//不是很可爱吗
RESTORED RESULT: 哥吉拉不是很可爱吗
```

## Concerns

* 有點擔心讓 `engine_data` 的 json 檔更加複雜，也不確定這樣的命名是否符合專案的喜好
* 把 Python regex 的 pattern 寫在 json 實在很不美觀，尤其要加一堆 escape 倒斜線很容易就寫錯
* 需要清楚的文件來說明怎麼改 config。原本想要同步更新文件，不過 wiki 沒辦法用 PR 同時更新。只能另外寫了 (如果此修改有被接受的話)

