### PR TITLE
fix: avoid stuck canceling when cache database cannot be opened

### DIFF
--- a/advanced.py
+++ b/advanced.py
@@ -86,77 +86,88 @@ class PreparationWorker(QObject):
     @pyqtSlot()
     def prepare_ebook_data(self):
         self.on_working = True
-        input_path = self.ebook.get_input_path()
-        element_handler = get_element_handler(
-            self.engine_class.placeholder, self.engine_class.separator,
-            self.ebook.target_direction)
-        merge_length = str(element_handler.get_merge_length())
-        encoding = ''
-        if self.ebook.encoding.lower() != 'utf-8':
-            encoding = self.ebook.encoding.lower()
-        cache_id = uid(
-            input_path + self.engine_class.name + self.ebook.target_lang
-            + merge_length + encoding)
-        cache = get_cache(cache_id)
+        cache = None
+        try:
+            input_path = self.ebook.get_input_path()
+            element_handler = get_element_handler(
+                self.engine_class.placeholder, self.engine_class.separator,
+                self.ebook.target_direction)
+            merge_length = str(element_handler.get_merge_length())
+            encoding = ''
+            if self.ebook.encoding.lower() != 'utf-8':
+                encoding = self.ebook.encoding.lower()
+            cache_id = uid(
+                input_path + self.engine_class.name + self.ebook.target_lang
+                + merge_length + encoding)
+            cache = get_cache(cache_id)
 
-        if cache.is_fresh() or not cache.is_persistence():
-            self.progress_detail.emit(
-                'Start processing the ebook: %s' % self.ebook.title)
-            cache.set_info('title', self.ebook.title)
-            cache.set_info('engine_name', self.engine_class.name)
-            cache.set_info('target_lang', self.ebook.target_lang)
-            cache.set_info('merge_length', merge_length)
-            cache.set_info('plugin_version', EbookTranslator.__version__)
-            cache.set_info('calibre_version', __version__)
-            # --------------------------
-            a = time.time()
-            # --------------------------
-            self.progress_message.emit(_('Extracting ebook content...'))
-            try:
-                elements = extract_item(
-                    input_path, self.ebook.input_format, self.ebook.encoding,
-                    self.progress_detail.emit)
-            except Exception:
-                self.progress_message.emit(
-                    _('Failed to extract ebook content'))
-                self.progress_detail.emit('\n' + traceback_error())
+            if cache.is_fresh() or not cache.is_persistence():
+                self.progress_detail.emit(
+                    'Start processing the ebook: %s' % self.ebook.title)
+                cache.set_info('title', self.ebook.title)
+                cache.set_info('engine_name', self.engine_class.name)
+                cache.set_info('target_lang', self.ebook.target_lang)
+                cache.set_info('merge_length', merge_length)
+                cache.set_info('plugin_version', EbookTranslator.__version__)
+                cache.set_info('calibre_version', __version__)
+                # --------------------------
+                a = time.time()
+                # --------------------------
+                self.progress_message.emit(_('Extracting ebook content...'))
+                try:
+                    elements = extract_item(
+                        input_path, self.ebook.input_format,
+                        self.ebook.encoding, self.progress_detail.emit)
+                except Exception:
+                    self.progress_message.emit(
+                        _('Failed to extract ebook content'))
+                    self.progress_detail.emit('\n' + traceback_error())
+                    self.progress.emit(100)
+                    self.clean_cache(cache)
+                    return
+                if self.canceled:
+                    self.clean_cache(cache)
+                    return
+                self.progress.emit(30)
+                b = time.time()
+                self.progress_detail.emit('extracting timing: %s' % (b - a))
+                if self.canceled:
+                    self.clean_cache(cache)
+                    return
+                # --------------------------
+                self.progress_message.emit(_('Filtering ebook content...'))
+                original_group = element_handler.prepare_original(elements)
+                self.progress.emit(80)
+                c = time.time()
+                self.progress_detail.emit('filtering timing: %s' % (c - b))
+                if self.canceled:
+                    self.clean_cache(cache)
+                    return
+                # --------------------------
+                self.progress_message.emit(_('Preparing user interface...'))
+                cache.save(original_group)
                 self.progress.emit(100)
-                self.clean_cache(cache)
-                return
-            if self.canceled:
-                self.clean_cache(cache)
-                return
-            self.progress.emit(30)
-            b = time.time()
-            self.progress_detail.emit('extracting timing: %s' % (b - a))
-            if self.canceled:
-                self.clean_cache(cache)
-                return
-            # --------------------------
-            self.progress_message.emit(_('Filtering ebook content...'))
-            original_group = element_handler.prepare_original(elements)
-            self.progress.emit(80)
-            c = time.time()
-            self.progress_detail.emit('filtering timing: %s' % (c - b))
-            if self.canceled:
-                self.clean_cache(cache)
-                return
-            # --------------------------
-            self.progress_message.emit(_('Preparing user interface...'))
-            cache.save(original_group)
-            self.progress.emit(100)
-            d = time.time()
-            self.progress_detail.emit('cache timing: %s' % (d - c))
-            if self.canceled:
-                self.clean_cache(cache)
-                return
-        else:
-            self.progress_detail.emit(
-                'Loading data from cache and preparing user interface...')
-            time.sleep(0.1)
+                d = time.time()
+                self.progress_detail.emit('cache timing: %s' % (d - c))
+                if self.canceled:
+                    self.clean_cache(cache)
+                    return
+            else:
+                self.progress_detail.emit(
+                    'Loading data from cache and preparing user interface...')
+                time.sleep(0.1)
 
-        self.finished.emit(cache_id)
-        self.on_working = False
+            self.finished.emit(cache_id)
+        except Exception:
+            self.progress_message.emit(_('Failed to load ebook data'))
+            self.progress_detail.emit('\n' + traceback_error())
+            self.progress.emit(100)
+            if cache is not None:
+                self.clean_cache(cache)
+            else:
+                self.close.emit(1)
+        finally:
+            self.on_working = False
 
 
 class TranslationWorker(QObject):


### PR DESCRIPTION
## Summary
- catch uncaught exceptions in preparation worker (including cache open failures)
- always reset on_working in finally so cancel flow can complete
- close the dialog path on preparation failure instead of leaving UI stuck in "Canceling..."

## Repro
Trigger sqlite3.OperationalError: unable to open database file during advanced translation preparation (for example invalid or unwritable cache path).

## Expected
Preparation shows failure details and exits cleanly instead of hanging in canceling state.

## Testing
- not run (logic change only)