### PR TITLE
Important:  revert d68ff fix break semantic html

### DIFF
--- a/lib/element.py
+++ b/lib/element.py
@@ -493,15 +493,6 @@ class PageElement(Element):
 
 
 class Extraction:
-    # List the necessary non-inline-level elements according to the HTML spec:
-    # https://html.spec.whatwg.org/multipage/rendering.html#non-replaced-elements
-    non_inline_elements = (
-        'address', 'blockquote', 'dialog', 'div', 'figure', 'figcaption',
-        'footer', 'header', 'legend', 'main', 'p', 'pre', 'search', 'article',
-        'aside', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hgroup', 'nav',
-        'section', 'dd', 'dl', 'dt', 'menu', 'ol', 'ul', 'table', 'caption',
-        'colgroup', 'col', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th')
-
     def __init__(
             self, pages, priority_rules, rule_mode, filter_scope, filter_rules,
             ignore_rules):
@@ -567,16 +558,6 @@ class Extraction:
                 return True
         return False
 
-    def is_inline_only(self, element: etree._Element):
-        """The purpose of this method is to ensure that if the element contains
-        only inline-level elements, it is regarded as a whole paragraph; there
-        is no need to further separate its children.
-        """
-        for tag in self.non_inline_elements:
-            if element.find(f'./x:{tag}', namespaces=ns) is not None:
-                return False
-        return True
-
     def need_ignore(self, element):
         for pattern in self.ignore_patterns:
             if element.xpath(pattern, namespaces=ns):
@@ -594,7 +575,7 @@ class Extraction:
                 elements.append(PageElement(element, page_id, True))
                 continue
             element_has_content = False
-            if self.is_priority(element) or self.is_inline_only(element) or (
+            if self.is_priority(element) or (
                     element.text is not None and trim(element.text) != ''):
                 element_has_content = True
             else:

--- a/tests/lib/test_element.py
+++ b/tests/lib/test_element.py
@@ -1105,19 +1105,6 @@ class TestExtraction(unittest.TestCase):
             xhtml.find('.//x:div[3]/x:p', namespaces=ns), elements[2].element)
         self.assertTrue(elements[3].ignored)
 
-    def test_extract_elements_with_sole_block_level_element(self):
-        xhtml = etree.XML(b"""<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-<head><title>Document</title></head>
-<body class="test"><div><span>a </span><span>, b</span></div></body>
-</html>""")
-        root = xhtml.find('.//x:body', namespaces=ns)
-        self.extraction.load_ignore_patterns()
-        elements = self.extraction.extract_elements('test', root, [])
-        self.assertEqual(1, len(elements))
-        self.assertEqual('div', elements[0].get_name())
-
     def test_filter_content(self):
         def elements(markups):
             return [

--- a/tests/lib/test_element.py
+++ b/tests/lib/test_element.py
@@ -1000,13 +1000,6 @@ class TestExtraction(unittest.TestCase):
             with self.subTest(item=item):
                 self.assertFalse(self.extraction.is_priority(etree.XML(item)))
 
-    def test_is_inline_only(self):
-        div = '<div xmlns="http://www.w3.org/1999/xhtml"><span>a</span></div>'
-        self.assertTrue(self.extraction.is_inline_only(etree.XML(div)))
-
-        div = '<div xmlns="http://www.w3.org/1999/xhtml"><div>a</div></div>'
-        self.assertFalse(self.extraction.is_inline_only(etree.XML(div)))
-
     def test_need_ignore(self):
         self.extraction.ignore_rules = ['table', 'p.a']
         self.extraction.load_ignore_patterns()


### PR DESCRIPTION
I have thoroughly analyzed the source code in commit https://github.com/bookfere/Ebook-Translator-Calibre-Plugin/commit/ d68ff7d1ae6c860e8c3bb9f95d45eae643104e52 does not provide any benefits; on the contrary, it causes a serious error that breaks the semantic HTML structure. For example, if I have `ol > li > a`, this code will remove the `li` and `a` elements, leaving only `ol` and `text`.