### PR TITLE
feat: Add glossaries & chapter-merge; deepseek-api fix

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -6,6 +6,8 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  # 添加手动触发事件
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/advanced.py
+++ b/advanced.py
@@ -1,3 +1,4 @@
+import os
 import time
 from types import MethodType
 
@@ -6,7 +7,7 @@ from qt.core import (  # type: ignore
     QPlainTextEdit, QPushButton, QSplitter, QLabel, QThread, QLineEdit,
     QGridLayout, QProgressBar, pyqtSignal, pyqtSlot, QPixmap, QEvent,
     QStackedWidget, QSpacerItem, QTabWidget, QCheckBox,
-    QComboBox, QSizePolicy)
+    QComboBox, QSizePolicy, QFileDialog, QMessageBox)
 from calibre.constants import __version__  # type: ignore
 from calibre.gui2 import I  # type: ignore
 from calibre.utils.localization import _  # type: ignore
@@ -16,7 +17,7 @@ from .lib.utils import uid, traceback_error
 from .lib.config import get_config
 from .lib.encodings import encoding_list
 from .lib.cache import Paragraph, get_cache
-from .lib.translation import get_engine_class, get_translator, get_translation
+from .lib.translation import get_engine_class, get_translator, get_translation, Glossary
 from .lib.element import get_element_handler
 from .lib.conversion import extract_item, extra_formats
 from .engines.openai import ChatgptTranslate, ChatgptBatchTranslate
@@ -174,6 +175,8 @@ class TranslationWorker(QObject):
         self.source_lang = ebook.source_lang
         self.target_lang = ebook.target_lang
         self.engine_class = engine_class
+        self.glossary_path = getattr(ebook, 'glossary_path', None)
+        self.glossary_reverse = getattr(ebook, 'glossary_reverse', False)
 
         self.on_working = False
         self.canceled = False
@@ -207,7 +210,9 @@ class TranslationWorker(QObject):
         translator = get_translator(self.engine_class)
         translator.set_source_lang(self.source_lang)
         translator.set_target_lang(self.target_lang)
-        translation = get_translation(translator)
+        translation = get_translation(
+            translator, glossary_path=self.glossary_path,
+            glossary_reverse=self.glossary_reverse)
         translation.set_fresh(fresh)
         translation.set_logging(
             lambda text, error=False: self.logging.emit(text, error))
@@ -347,6 +352,56 @@ class CreateTranslationProject(QDialog):
                     target_lang_code)
                 index = direction_list.findData(direction)
                 direction_list.setCurrentIndex(index)
+
+        # === Per-book Glossary ===
+        glossary_group = QGroupBox(_('Glossary (per book)'))
+        glossary_layout = QGridLayout(glossary_group)
+        self.glossary_path_edit = QLineEdit()
+        self.glossary_path_edit.setPlaceholderText(
+            _('Choose a glossary file (.txt/.json)'))
+        self.glossary_path_edit.setMinimumWidth(200)
+        glossary_choose_btn = QPushButton(_('Choose'))
+        self.glossary_reverse_cb = QCheckBox(_('Reverse'))
+        self.glossary_reverse_cb.setToolTip(
+            _('Swap source/target terms in output'))
+        self.glossary_preview_btn = QPushButton(_('Preview'))
+        self.glossary_preview_btn.setEnabled(False)
+        glossary_layout.addWidget(QLabel(_('File')), 0, 0)
+        glossary_layout.addWidget(self.glossary_path_edit, 0, 1, 1, 2)
+        glossary_layout.addWidget(glossary_choose_btn, 0, 3)
+        glossary_layout.addWidget(self.glossary_reverse_cb, 1, 0)
+        glossary_layout.addWidget(self.glossary_preview_btn, 1, 3)
+        layout.addWidget(glossary_group, 2, 0, 1, 6)
+
+        def choose_glossary():
+            path, _ = QFileDialog.getOpenFileName(
+                filter='Glossary files (*.txt *.json);;All files (*.*)')
+            if path:
+                self.glossary_path_edit.setText(path)
+                self.glossary_preview_btn.setEnabled(True)
+                self.ebook.set_glossary_path(path)
+        glossary_choose_btn.clicked.connect(choose_glossary)
+
+        def preview_glossary():
+            path = self.glossary_path_edit.text()
+            if not path or not os.path.exists(path):
+                return
+            g = Glossary(('{id_{}}', r'({{\\s*)+id\\s*_\\s*{}\\s*(\\s*}})+'))
+            g.load_from_file(path)
+            pairs = g.get_preview()
+            preview_text = '\\n'.join(
+                [f'{s} → {t}' for s, t in pairs[:50]])
+            if len(pairs) > 50:
+                preview_text += f'\\n\\n... and {len(pairs) - 50} more entries'
+            if not preview_text:
+                preview_text = _('No glossary entries found.')
+            QMessageBox.information(
+                self, _('Glossary Preview ({})').format(len(pairs)),
+                preview_text)
+        self.glossary_preview_btn.clicked.connect(preview_glossary)
+
+        self.glossary_reverse_cb.toggled.connect(
+            lambda checked: self.ebook.set_glossary_reverse(checked))
 
         return widget
 

--- a/engines/base.py
+++ b/engines/base.py
@@ -52,6 +52,8 @@ class Base:
         self.proxy_port: int | None = None
 
         self.merge_enabled = False
+        self.merge_by_chapter = False
+        self.chapter_merge_length = 8000
         self.api_keys: list = self.config.get('api_keys', [])[:]
         self.bad_api_keys = []
         self.api_key = self.get_api_key()
@@ -146,6 +148,12 @@ class Base:
 
     def set_merge_enabled(self, enable):
         self.merge_enabled = enable
+
+    def set_merge_by_chapter(self, enable):
+        self.merge_by_chapter = enable
+
+    def set_chapter_merge_length(self, length):
+        self.chapter_merge_length = length
 
     def set_source_lang(self, source_lang: str) -> None:
         self.source_lang = source_lang

--- a/engines/deepseek.py
+++ b/engines/deepseek.py
@@ -6,7 +6,7 @@ load_translations()  # type: ignore
 class DeepseekTranslate(ChatgptTranslate):
     name = 'DeepSeek'
     alias = 'DeepSeek (Chat)'
-    endpoint = 'https://api.deepseek.com/v1/chat/completions'
+    endpoint = 'https://api.deepseek.com/chat/completions'
     temperature = 1.3
 
     concurrency_limit = 0

--- a/engines/openai.py
+++ b/engines/openai.py
@@ -81,6 +81,13 @@ class ChatgptTranslate(GenAI):
         if self.merge_enabled:
             prompt += (' Ensure that placeholders matching the pattern '
                        '{{id_\\d+}} in the content are retained.')
+        if getattr(self, 'merge_by_chapter', False):
+            prompt += (
+                ' The content is divided into segments separated by '
+                'the delimiter "' + self.separator + '". '
+                'You MUST preserve exactly the same number of segments '
+                'and the same delimiter between them in your translation. '
+                'Do not merge or split segments.')
         return prompt
 
     def get_headers(self):

--- a/lib/config.py
+++ b/lib/config.py
@@ -42,8 +42,12 @@ defaults: dict[str, Any] = {
     'custom_engines': {},
     'glossary_enabled': False,
     'glossary_path': None,
+    'glossary_reverse': False,
+    'glossary_per_book': {},
     'merge_enabled': False,
     'merge_length': 1800,
+    'merge_by_chapter': False,
+    'chapter_merge_length': 8000,
     'ebook_metadata': {},
     'search_paths': [],
 }

--- a/lib/conversion.py
+++ b/lib/conversion.py
@@ -188,7 +188,8 @@ def extract_book(input_path, encoding):
 
 def convert_item(
         ebook_title, input_path, output_path, source_lang, target_lang,
-        cache_only, is_batch, format, encoding, direction, notification):
+        cache_only, is_batch, format, encoding, direction, notification,
+        glossary_path=None, glossary_reverse=None):
     """The following parameters need attention:
     :cache_only: Only use the translation which exists in the cache.
     :notification: It is automatically added by arbitrary_n.
@@ -218,7 +219,8 @@ def convert_item(
     cache.set_info('calibre_version', __version__)
 
     translation = get_translation(
-        translator, lambda text, error=False: log.info(text))
+        translator, lambda text, error=False: log.info(text),
+        glossary_path=glossary_path, glossary_reverse=glossary_reverse)
     translation.set_batch(is_batch)
     translation.set_callback(cache.update_paragraph)
 
@@ -276,7 +278,9 @@ class ConversionWorker:
                 'convert_item',
                 (ebook.title, input_path, output_path, ebook.source_lang,
                  ebook.target_lang, cache_only, is_batch, ebook.input_format,
-                 ebook.encoding, ebook.target_direction)),
+                 ebook.encoding, ebook.target_direction,
+                 getattr(ebook, 'glossary_path', None),
+                 getattr(ebook, 'glossary_reverse', False))),
             description=(_('[{} > {}] Translating "{}"').format(
                 ebook.source_lang, ebook.target_lang, ebook.title)))
         self.working_jobs[job] = (ebook, output_path)

--- a/lib/ebook.py
+++ b/lib/ebook.py
@@ -18,6 +18,8 @@ class Ebook:
         self.custom_title = None
         self.encoding = 'utf-8'
         self.target_direction = 'auto'
+        self.glossary_path = None
+        self.glossary_reverse = False
 
     def set_input_format(self, format):
         self.input_format = format
@@ -42,6 +44,12 @@ class Ebook:
 
     def set_target_direction(self, direction):
         self.target_direction = direction
+
+    def set_glossary_path(self, path):
+        self.glossary_path = path
+
+    def set_glossary_reverse(self, reverse):
+        self.glossary_reverse = reverse
 
     def get_input_path(self):
         return self.files.get(self.input_format)

--- a/lib/element.py
+++ b/lib/element.py
@@ -641,6 +641,8 @@ class ElementHandler:
         self.position = position
 
         self.merge_length = 0
+        self.merge_by_chapter = False
+        self.chapter_merge_length = 8000
         self.target_direction = None
 
         self.translation_lang = None
@@ -658,7 +660,15 @@ class ElementHandler:
         self.merge_length = length
 
     def get_merge_length(self):
+        if self.merge_by_chapter:
+            return self.chapter_merge_length
         return self.merge_length
+
+    def set_merge_by_chapter(self, enable):
+        self.merge_by_chapter = enable
+
+    def set_chapter_merge_length(self, length):
+        self.chapter_merge_length = length
 
     def set_target_direction(self, direction):
         self.target_direction = direction
@@ -739,7 +749,35 @@ class ElementHandler:
 
 
 class ElementHandlerMerge(ElementHandler):
+    def _prepare_element(self, element):
+        """Configure a single element with handler settings."""
+        element.set_placeholder(self.placeholder)
+        element.set_position(self.position)
+        element.set_target_direction(self.target_direction)
+        element.set_translation_lang(self.translation_lang)
+        element.set_original_color(self.original_color)
+        element.set_translation_color(self.translation_color)
+        if self.column_gap is not None:
+            element.set_column_gap(self.column_gap)
+        element.set_remove_pattern(self.remove_pattern)
+        element.set_reserve_pattern(self.reserve_pattern)
+        return element.get_raw(), element.get_content() + self.separator
+
+    def _flush_merge(self, oid, raw, txt):
+        """Flush accumulated merged text into an original entry."""
+        if not txt:
+            return oid
+        md5 = uid('%s%s' % (oid, txt))
+        self.originals.append((oid, md5, raw, txt, False))
+        return oid + 1
+
     def prepare_original(self, elements):
+        if self.merge_by_chapter:
+            return self._prepare_by_chapter(elements)
+        return self._prepare_by_length(elements)
+
+    def _prepare_by_length(self, elements):
+        """Original behaviour: merge consecutive elements up to merge_length chars."""
         raw = ''
         txt = ''
         oid = 0
@@ -747,32 +785,49 @@ class ElementHandlerMerge(ElementHandler):
             self.elements[eid] = element
             if element.ignored:
                 continue
-            element.set_placeholder(self.placeholder)
-            element.set_position(self.position)
-            element.set_target_direction(self.target_direction)
-            element.set_translation_lang(self.translation_lang)
-            element.set_original_color(self.original_color)
-            element.set_translation_color(self.translation_color)
-            if self.column_gap is not None:
-                element.set_column_gap(self.column_gap)
-            element.set_remove_pattern(self.remove_pattern)
-            element.set_reserve_pattern(self.reserve_pattern)
-            code = element.get_raw()
-            content = element.get_content()
-            content += self.separator
+            code, content = self._prepare_element(element)
             if len(txt + content) < self.merge_length:
                 raw += code + self.separator
                 txt += content
                 continue
             elif txt:
-                md5 = uid('%s%s' % (oid, txt))
-                self.originals.append((oid, md5, raw, txt, False))
-                oid += 1
+                oid = self._flush_merge(oid, raw, txt)
             raw = code
             txt = content
-        md5 = uid('%s%s' % (oid, txt))
-        if txt:
-            self.originals.append((oid, md5, raw, txt, False))
+        oid = self._flush_merge(oid, raw, txt)
+        return self.originals
+
+    def _prepare_by_chapter(self, elements):
+        """Chapter-level merge: group elements by page_id (XHTML chapter),
+        then subdivide if a chapter exceeds chapter_merge_length."""
+        oid = 0
+        # Group elements by page_id, preserving order within each page
+        pages = {}
+        page_order = []
+        for eid, element in enumerate(elements):
+            self.elements[eid] = element
+            if element.ignored:
+                continue
+            page_id = getattr(element, 'page_id', None) or '__default__'
+            if page_id not in pages:
+                pages[page_id] = []
+                page_order.append(page_id)
+            pages[page_id].append(element)
+        # Process each page/chapter
+        for page_id in page_order:
+            page_elements = pages[page_id]
+            raw = ''
+            txt = ''
+            for element in page_elements:
+                code, content = self._prepare_element(element)
+                if self.chapter_merge_length > 0 and \
+                        len(txt + content) > self.chapter_merge_length and txt:
+                    oid = self._flush_merge(oid, raw, txt)
+                    raw = ''
+                    txt = ''
+                raw += code + self.separator
+                txt += content
+            oid = self._flush_merge(oid, raw, txt)
         return self.originals
 
     def align_paragraph(self, paragraph):
@@ -885,9 +940,11 @@ def get_element_handler(placeholder, separator, direction):
     position = config.get('translation_position') or 'below'
     position = position_alias.get(position) or position
     handler = ElementHandler(placeholder, separator, position)
-    if config.get('merge_enabled'):
+    if config.get('merge_enabled') or config.get('merge_by_chapter'):
         handler = ElementHandlerMerge(placeholder, separator, position)
         handler.set_merge_length(config.get('merge_length'))
+        handler.set_merge_by_chapter(config.get('merge_by_chapter'))
+        handler.set_chapter_merge_length(config.get('chapter_merge_length'))
     handler.set_target_direction(direction)
     column_gap = config.get('column_gap') or {}
     gap_type = column_gap.get('_type')

--- a/lib/translation.py
+++ b/lib/translation.py
@@ -23,21 +23,54 @@ class Glossary:
     def __init__(self, placeholder):
         self.placeholder = placeholder
         self.glossary = []
+        self.reverse = False
 
     def load_from_file(self, path):
+        """Load glossary from file. Supports JSON (*.json) and legacy text format."""
         content = None
         try:
-            with open(path, 'r', newline=None) as f:
+            with open(path, 'r', newline=None, encoding='utf-8') as f:
                 content = f.read().strip()
         except Exception:
             pass
         if not content:
             return
+        # Detect JSON format (starts with '{')
+        if content.startswith('{'):
+            self._load_from_json(content)
+        else:
+            self._load_from_text(content)
+
+    def load_from_dict(self, data):
+        """Load glossary directly from a dictionary {source: target}."""
+        for key, value in data.items():
+            self.glossary.append((str(key), str(value)))
+
+    def _load_from_json(self, content):
+        """Parse JSON format: {"source_term": "target_term", ...}"""
+        try:
+            data = json.loads(content)
+            if isinstance(data, dict):
+                self.load_from_dict(data)
+        except json.JSONDecodeError:
+            pass
+
+    def _load_from_text(self, content):
+        """Parse legacy text format: groups separated by blank lines."""
         groups = re.split(r'\n{2,}', content.strip(u'\ufeff'))
         for group in filter(trim, groups):
             group = group.split('\n')
             self.glossary.append(
                 (group[0], group[0] if len(group) < 2 else group[1]))
+
+    def set_reverse(self, reverse):
+        """When reverse=True, the replacement direction is swapped:
+        source→target in original text, and target→source in translation output."""
+        self.reverse = reverse
+
+    def get_preview(self):
+        """Return a list of (source, target) pairs for UI preview."""
+        return list(self.glossary)
 
     def replace(self, content):
         for wid, words in enumerate(self.glossary):
@@ -48,8 +81,9 @@ class Glossary:
     def restore(self, content):
         for wid, words in enumerate(self.glossary):
             pattern = self.placeholder[1].format(format(wid, '06'))
-            # Eliminate the impact of backslashes on substitution.
-            content = re.sub(pattern, lambda _: words[1], content)
+            # When reversed, swap source↔target for the restoration
+            target = words[0] if self.reverse else words[1]
+            content = re.sub(pattern, lambda _, t=target: t, content)
         return content
 
 
@@ -275,14 +309,24 @@ def get_translator(engine_class=None):
             host, port = proxy_setting.get(proxy_type) or ['', '']
             translator.set_proxy(proxy_type, host, port)
     translator.set_merge_enabled(config.get('merge_enabled'))
+    translator.set_merge_by_chapter(config.get('merge_by_chapter'))
+    translator.set_chapter_merge_length(config.get('chapter_merge_length'))
     return translator
 
 
-def get_translation(translator, log=None):
+def get_translation(translator, log=None, glossary_path=None, glossary_reverse=None):
     config = get_config()
     glossary = Glossary(translator.placeholder)
-    if config.get('glossary_enabled'):
-        glossary.load_from_file(config.get('glossary_path'))
+    # Per-book glossary takes priority over global glossary
+    effective_path = glossary_path or (
+        config.get('glossary_path') if config.get('glossary_enabled') else None)
+    if effective_path:
+        glossary.load_from_file(effective_path)
+    # Reverse setting: per-book > global config
+    effective_reverse = glossary_reverse
+    if effective_reverse is None:
+        effective_reverse = config.get('glossary_reverse', False)
+    glossary.set_reverse(effective_reverse)
     translation = Translation(translator, glossary)
     if get_config().get('log_translation'):
         translation.set_logging(log)

--- a/setting.py
+++ b/setting.py
@@ -246,19 +246,47 @@ class TranslationSetting(QDialog):
         merge_enabled = QCheckBox(_('Enable'))
         self.merge_length = QSpinBox()
         self.merge_length.setRange(1, 999999)
+        self.merge_by_chapter = QCheckBox(_('By Chapter'))
+        self.chapter_merge_length = QSpinBox()
+        self.chapter_merge_length.setRange(100, 999999)
+        self.chapter_merge_length.setToolTip(_(
+            'Max characters per chapter chunk. '
+            'Chapters exceeding this limit will be split.'))
         merge_layout.addWidget(merge_enabled)
         merge_layout.addWidget(self.merge_length)
         merge_layout.addWidget(QLabel(_(
             'The number of characters to translate at once.')))
+        merge_layout.addWidget(self.merge_by_chapter)
+        merge_layout.addWidget(self.chapter_merge_length)
         merge_layout.addStretch(1)
         layout.addWidget(merge_group)
 
         self.disable_wheel_event(self.merge_length)
+        self.disable_wheel_event(self.chapter_merge_length)
 
         self.merge_length.setValue(self.config.get('merge_length'))
         merge_enabled.setChecked(self.config.get('merge_enabled'))
+
+        self.merge_by_chapter.setChecked(self.config.get('merge_by_chapter'))
+        self.merge_by_chapter.setEnabled(self.config.get('merge_enabled'))
+        self.chapter_merge_length.setValue(
+            self.config.get('chapter_merge_length'))
+        self.chapter_merge_length.setEnabled(
+            self.config.get('merge_by_chapter') and self.config.get('merge_enabled'))
+        self.merge_length.setDisabled(self.config.get('merge_by_chapter'))
+
+        def toggle_merge_mode(checked):
+            self.config.update(merge_by_chapter=checked)
+            self.chapter_merge_length.setEnabled(checked)
+            self.merge_length.setDisabled(checked)
+            if checked and not merge_enabled.isChecked():
+                merge_enabled.setChecked(True)
+        self.merge_by_chapter.clicked.connect(toggle_merge_mode)
+
         merge_enabled.clicked.connect(
             lambda checked: self.config.update(merge_enabled=checked))
+        merge_enabled.clicked.connect(
+            lambda checked: self.merge_by_chapter.setEnabled(checked))
 
         # Network Proxy
         proxy_group = QGroupBox(_('Network Proxy'))
@@ -1021,14 +1049,18 @@ class TranslationSetting(QDialog):
 
         # Glossary
         glossary_group = QGroupBox(_('Translation Glossary'))
-        glossary_layout = QHBoxLayout(glossary_group)
+        glossary_layout = QGridLayout(glossary_group)
         self.glossary_enabled = QCheckBox(_('Enable'))
         self.glossary_path = QLineEdit()
         self.glossary_path.setPlaceholderText(_('Choose a glossary file'))
         glossary_choose = QPushButton(_('Choose'))
-        glossary_layout.addWidget(self.glossary_enabled)
-        glossary_layout.addWidget(self.glossary_path)
-        glossary_layout.addWidget(glossary_choose)
+        self.glossary_reverse = QCheckBox(_('Reverse'))
+        self.glossary_reverse.setToolTip(_(
+            'Swap source and target terms in translation output'))
+        glossary_layout.addWidget(self.glossary_enabled, 0, 0)
+        glossary_layout.addWidget(self.glossary_path, 0, 1)
+        glossary_layout.addWidget(glossary_choose, 0, 2)
+        glossary_layout.addWidget(self.glossary_reverse, 0, 3)
         layout.addWidget(glossary_group)
 
         self.glossary_enabled.setChecked(self.config.get('glossary_enabled'))
@@ -1036,9 +1068,14 @@ class TranslationSetting(QDialog):
             lambda checked: self.config.update(glossary_enabled=checked))
 
         self.glossary_path.setText(self.config.get('glossary_path'))
+        self.glossary_reverse.setChecked(
+            self.config.get('glossary_reverse', False))
+        self.glossary_reverse.clicked.connect(
+            lambda checked: self.config.update(glossary_reverse=checked))
 
         def choose_glossary_file():
-            path = QFileDialog.getOpenFileName(filter="Text files (*.txt)")
+            path = QFileDialog.getOpenFileName(
+                filter="Glossary files (*.txt *.json);;All files (*.*)")
             self.glossary_path.setText(path[0])
         glossary_choose.clicked.connect(choose_glossary_file)
 
@@ -1259,6 +1296,8 @@ class TranslationSetting(QDialog):
 
         # Merge length
         self.config.update(merge_length=self.merge_length.value())
+        self.config.update(merge_by_chapter=self.merge_by_chapter.isChecked())
+        self.config.update(chapter_merge_length=self.chapter_merge_length.value())
 
         # Proxy setting
         proxy_setting = self.config.get('proxy_setting') or {}

--- a/tests/lib/test_config.py
+++ b/tests/lib/test_config.py
@@ -41,8 +41,12 @@ class TestFunction(unittest.TestCase):
             'custom_engines': {},
             'glossary_enabled': False,
             'glossary_path': None,
+            'glossary_reverse': False,
+            'glossary_per_book': {},
             'merge_enabled': False,
             'merge_length': 1800,
+            'merge_by_chapter': False,
+            'chapter_merge_length': 8000,
             'ebook_metadata': {},
             'search_paths': [],
         }

--- a/tests/lib/test_element.py
+++ b/tests/lib/test_element.py
@@ -437,7 +437,7 @@ class TestPageElement(unittest.TestCase):
         self.assertEqual(
             '<img src="w2.jpg"></img>', self.element.reserve_elements[4])
         self.assertEqual(
-            '<img alt="{\D}" src="w3.jpg"></img>', # type: ignore
+            r'<img alt="{\D}" src="w3.jpg"></img>', # type: ignore
             self.element.reserve_elements[5])
         self.assertEqual(
             '<img src="w3.jpg"></img>', self.element.reserve_elements[6])

--- a/tests/lib/test_translation.py
+++ b/tests/lib/test_translation.py
@@ -14,7 +14,7 @@ module_name = 'calibre_plugins.ebook_translator.lib.translation'
 class TestGlossary(unittest.TestCase):
     @patch(f'{module_name}.open')
     def test_load_from_file(self, mock_open):
-        def mock_open_function(path, mode, newline=None):
+        def mock_open_function(path, mode, newline=None, encoding=None):
             if path == '/path/to/glossary.txt':
                 file = Mock()
                 file.read.return_value.strip.return_value = 'a\n\n\nb\nZ\n'


### PR DESCRIPTION
## PR Description

**Title:** Introduce per-book and global glossary support, chapter-based merge mode, and assorted fixes.

### Summary

This PR adds per-book glossary configuration, a global glossary, a new chapter-aware merge strategy, and several bug fixes and UI improvements.

### Key Changes

**Glossary Enhancements**  
- Related to #568
- Support JSON and legacy text glossary formats.
- Add `load_from_dict` method, reverse match mode, preview, and safer file reading.

**Translation API** 
- `get_translation` now accepts per-call `glossary_path` and `glossary_reverse` parameters.
- Per-book values override global settings.

**UI Updates**
- Project dialog and settings: choose/preview per-book glossary, toggle reverse mode.
- Global settings: add checkbox for global glossary reverse.

**Ebook Model**
- Extend model with `glossary_path` and `glossary_reverse` fields.
- Conversion worker and `convert_item` propagate these values.

**New Merge Mode: merge_by_chapter**
- `ElementHandler`: add `merge_by_chapter` and `chapter_merge_length`; implement chapter-level grouping and splitting while preserving original length-based merging.
- Engine base: add flags and setters for chapter merge.
- OpenAI engine: update prompt to preserve chapter boundaries when chapter merge is enabled.

**Fixes & Misc**
- DeepSeek: fix API endpoint URL. #572 
- Config defaults: add `glossary_reverse`, `glossary_per_book`, `merge_by_chapter`, `chapter_merge_length`.
- Misc: import additions, UI wiring for file dialogs and message boxes, proper enable/disable interactions.

### Impact

- Per-book glossaries with optional reverse matching.
- Chapter-aware merge strategy for better translation coherence.
- Bug fixes and UI polish.