### PR TITLE
feat: add LiteLLM as AI gateway translation engine

### DIFF
--- a/engines/__init__.py
+++ b/engines/__init__.py
@@ -10,10 +10,12 @@ from .youdao import YoudaoTranslate
 from .baidu import BaiduTranslate
 from .microsoft import MicrosoftEdgeTranslate, AzureChatgptTranslate
 from .deepseek import DeepseekTranslate
+from .litellm import LitellmTranslate
 
 builtin_engines: tuple[type[Base], ...] = (
     GoogleFreeTranslateNew, GoogleFreeTranslateHtml, GoogleFreeTranslate,
     GoogleBasicTranslate, GoogleBasicTranslateADC, GoogleAdvancedTranslate,
     ChatgptTranslate, AzureChatgptTranslate, GeminiTranslate, ClaudeTranslate,
-    DeepseekTranslate, DeeplTranslate, DeeplProTranslate, DeeplFreeTranslate,
-    MicrosoftEdgeTranslate, YoudaoTranslate, BaiduTranslate)
+    DeepseekTranslate, LitellmTranslate, DeeplTranslate, DeeplProTranslate,
+    DeeplFreeTranslate, MicrosoftEdgeTranslate, YoudaoTranslate,
+    BaiduTranslate)

--- a/engines/litellm.py
+++ b/engines/litellm.py
@@ -1,0 +1,23 @@
+from calibre.utils.localization import _  # type: ignore
+
+from .openai import ChatgptTranslate
+
+
+load_translations()  # type: ignore
+
+
+class LitellmTranslate(ChatgptTranslate):
+    name = 'LiteLLM'
+    alias = 'LiteLLM (AI Gateway)'
+    endpoint = 'http://localhost:4000/v1/chat/completions'
+    api_key_hint = _('LiteLLM Proxy Key (master or virtual key)')
+
+    concurrency_limit = 0
+    request_interval = 0.0
+
+    models: list[str] = []
+    model: str | None = None
+
+    def __init__(self):
+        super().__init__()
+        self.model = self.config.get('model', self.model)


### PR DESCRIPTION
## Summary

Add [LiteLLM](https://litellm.ai) as a built-in translation engine. Users point the plugin at a LiteLLM proxy to access 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex, Groq, Ollama, and more) through one OpenAI-compatible endpoint.

## Motivation

LiteLLM addresses all of these through a single proxy that normalizes provider differences and drops unsupported parameters automatically.

## Changes

- `engines/litellm.py` - New `LitellmTranslate` engine subclassing `ChatgptTranslate` (follows the exact pattern of `DeepseekTranslate`)
- `engines/__init__.py` - Registered in `builtin_engines`

## How it works

`LitellmTranslate` subclasses `ChatgptTranslate` (just like `DeepseekTranslate` does) since LiteLLM exposes an OpenAI-compatible API. The only differences are:

- Default endpoint: `http://localhost:4000/v1/chat/completions`
- API key hint: "LiteLLM Proxy Key"
- No hardcoded model list - auto-discovered via `/v1/models` (inherited from `ChatgptTranslate.get_models()`)
- No concurrency limit or request interval (the proxy handles rate limiting)

No new dependencies are added. The plugin already uses raw HTTP via `mechanize`, so LiteLLM is accessed purely through the proxy's OpenAI-compatible REST API.

## Tests

**Live E2E (non-streaming, Claude Sonnet via Azure Foundry through LiteLLM proxy):**
```python
import json, urllib.request

endpoint = 'http://localhost:4111/v1/chat/completions'
headers = {
    'Content-Type': 'application/json',
    'Authorization': 'Bearer test-key',
}
body = json.dumps({
    'model': 'anthropic/claude-sonnet-4-6',
    'messages': [
        {'role': 'system', 'content': 'Translate from English to Spanish only.'},
        {'role': 'user', 'content': 'Hello, how are you today?'}
    ],
    'temperature': 1.0,
    'stream': False,
}).encode()

req = urllib.request.Request(endpoint, data=body, headers=headers, method='POST')
with urllib.request.urlopen(req, timeout=30) as resp:
    data = json.loads(resp.read().decode())
    print('Model:', data['model'])
    print('Translation:', data['choices'][0]['message']['content'])
```

```
Status: 200 OK
Model: anthropic/claude-sonnet-4-6
Translation: Hola, ¿cómo estás hoy?
Usage: {completion_tokens: 18, prompt_tokens: 31, total_tokens: 49}
```

**Live E2E (streaming):**
```python
body = json.dumps({
    'model': 'anthropic/claude-sonnet-4-6',
    'messages': [
        {'role': 'system', 'content': 'Translate from English to French.'},
        {'role': 'user', 'content': 'The weather is beautiful today.'}
    ],
    'temperature': 1.0,
    'stream': True,
}).encode()

req = urllib.request.Request(endpoint, data=body, headers=headers, method='POST')
with urllib.request.urlopen(req, timeout=30) as resp:
    for line in resp:
        line = line.decode('utf-8').strip()
        if line.startswith('data: ') and line != 'data: [DONE]':
            data = json.loads(line[6:])
            delta = data['choices'][0].get('delta', {})
            content = delta.get('content', '')
            if content:
                print(content, end='')
```

```
Streaming OK, translation: Le temps est magnifique aujourd'hui.
```

Full chain verified: plugin HTTP request -> LiteLLM proxy -> Azure Foundry -> Claude Sonnet -> response parsed correctly in both streaming and non-streaming modes.

## Risk / Compatibility

- Additive only. No existing engines modified.
- No new dependencies. Reuses the existing `ChatgptTranslate` HTTP request pattern via `mechanize`.
- 23-line engine file following the exact `DeepseekTranslate` pattern.

## Example usage

1. Start a LiteLLM proxy with your preferred providers:

```python
# litellm_config.yaml
model_list:
  - model_name: anthropic/claude-sonnet-4-6
    litellm_params:
      model: anthropic/claude-sonnet-4-6
      api_key: sk-ant-...
  - model_name: openai/gpt-4o
    litellm_params:
      model: gpt-4o
      api_key: sk-...

litellm_settings:
  drop_params: true
```

```bash
pip install litellm
litellm --config litellm_config.yaml --port 4000
```

2. In Calibre, select **LiteLLM (AI Gateway)** as the translation engine
3. Enter your LiteLLM proxy key and set the endpoint to `http://localhost:4000/v1/chat/completions`
4. Select a model from the auto-discovered list (fetched from `/v1/models`)
5. Translate your ebook - the proxy routes to the correct provider automatically
