### PR TITLE
Feature/Novel Mode — Context-Aware LLM Translation Pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ __Plugin Homepage__: [https://translator.bookfere.com](https://translator.bookfe
 
 ## Features
 
+* Support "Novel Mode" to better use LLM capabilities preserving a dynamic context.
 * Support both "Advanced Mode" and "Batch Mode" for different usage situations.
 * Support languages supported by the selected translation engine (e.g. Google Translate supports 134 languages)
 * Support multiple translation engines, including Google Translate, ChatGPT, Gemini, DeepL, etc.

--- a/build_plugin.sh
+++ b/build_plugin.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# build_plugin.sh — Crea lo zip installabile del plugin Ebook Translator.
+#
+# Uso:
+#   ./build_plugin.sh              # produce ebook-translator-calibre-plugin.zip
+#   ./build_plugin.sh mio-file.zip # produce mio-file.zip
+#
+# Lo script deve essere eseguito dall'interno della directory del plugin
+# (quella che contiene __init__.py).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEFAULT_OUTPUT="../ebook-translator-calibre-plugin.zip"
+OUTPUT="${1:-$DEFAULT_OUTPUT}"
+
+# Converti in percorso assoluto se relativo.
+if [[ "$OUTPUT" != /* ]]; then
+    OUTPUT="$SCRIPT_DIR/$OUTPUT"
+fi
+
+echo "Building plugin zip..."
+echo "  Source : $SCRIPT_DIR"
+echo "  Output : $OUTPUT"
+
+# Rimuovi eventuale zip precedente.
+rm -f "$OUTPUT"
+
+cd "$SCRIPT_DIR"
+
+zip -r "$OUTPUT" . \
+    -x "*.pyc" \
+    -x "./__pycache__" \
+    -x "./__pycache__/*" \
+    -x "*/__pycache__" \
+    -x "*/__pycache__/*" \
+    -x "./.git" \
+    -x "./.git/*" \
+    -x "./.github" \
+    -x "./.github/*" \
+    -x "./tests" \
+    -x "./tests/*" \
+    -x "./page" \
+    -x "./page/*" \
+    -x "./build_plugin.sh" \
+    > /dev/null
+
+SIZE=$(du -h "$OUTPUT" | cut -f1)
+echo "Done: $OUTPUT ($SIZE)"
+echo ""
+echo "Per installare in Calibre:"
+echo "  Preferenze → Plugin → Carica plugin da file → $OUTPUT"
+echo "  oppure: calibre-customize -a \"$OUTPUT\""

--- a/components/mode.py
+++ b/components/mode.py
@@ -45,17 +45,34 @@ class ModeSelection(QDialog):
         batch_description.setReadOnly(True)
         batch_button = QPushButton(_('Choose'))
 
+        novel_label = QLabel(_('Novel Mode'))
+        novel_label.setAlignment(Qt.AlignCenter)
+
+        novel_description = QPlainTextEdit()
+        novel_description.setPlainText(_(
+            'Chapter-aware translation for novels with LLMs (ChatGPT, '
+            'Claude, Gemini, Ollama). Maintains a running summary and a '
+            'dynamic glossary of characters and places for consistent, '
+            'context-aware translation across the whole book.'))
+        novel_description.setReadOnly(True)
+        novel_button = QPushButton(_('Choose'))
+
         choose_layout.addWidget(advanced_label, 0, 0)
         choose_layout.addWidget(advanced_description, 1, 0)
         choose_layout.addWidget(advanced_button, 2, 0)
         choose_layout.addWidget(batch_label, 0, 1)
         choose_layout.addWidget(batch_description, 1, 1)
         choose_layout.addWidget(batch_button, 2, 1)
+        choose_layout.addWidget(novel_label, 0, 2)
+        choose_layout.addWidget(novel_description, 1, 2)
+        choose_layout.addWidget(novel_button, 2, 2)
 
         advanced_button.clicked.connect(
             lambda: self.save_preferred_mode('advanced'))
         batch_button.clicked.connect(
             lambda: self.save_preferred_mode('batch'))
+        novel_button.clicked.connect(
+            lambda: self.save_preferred_mode('novel'))
 
         layout.addWidget(choose_group)
 

--- a/engines/base.py
+++ b/engines/base.py
@@ -209,7 +209,8 @@ class Base:
                 'method': self.method,
                 'proxy_uri': None,
                 'timeout': int(self.request_timeout),
-                'raw_object': self.stream
+                'raw_object': self.stream,
+                'keepalive': getattr(self, 'request_keepalive', False),
             }
             if self.proxy_type == 'socks5' and self.proxy_host is not None \
                     and self.proxy_port is not None:

--- a/engines/base.py
+++ b/engines/base.py
@@ -36,6 +36,13 @@ class Base:
     placeholder = ('{{{{id_{}}}}}', r'({{\s*)+id\s*_\s*{}\s*(\s*}})+')
     using_tip = None
 
+    # Novel Mode (see lib/novel.py) requires stateful, chat-style engines
+    # able to accept a customized system prompt with a running summary and
+    # glossary. Only GenAI subclasses opt-in to True. Kept as a plain class
+    # attribute rather than an ABC method so all builtin/custom engines can
+    # be introspected uniformly at UI level.
+    supports_novel_mode: bool = False
+
     concurrency_limit: int = 0
     request_interval: float = 0.0
     request_attempt: int = 3

--- a/engines/genai.py
+++ b/engines/genai.py
@@ -42,6 +42,30 @@ class GenAI(Base, ABC):
     # ``self.prompt`` (ChatGPT, Claude, Gemini) do not need any further
     # change: they will naturally pick up the overridden value.
 
+    structured_output_mode: str | None = None
+
+    def get_body_for_structured(self, text, schema=None):
+        """Return the request body with structured (JSON) output enabled.
+
+        Default implementation is a graceful fallback: it returns the same
+        body as :meth:`get_body`, so engines that do not override this
+        method silently continue with unstructured output. The novel
+        pipeline detects the lack of structured support via the
+        ``structured_output_mode`` class attribute and routes such
+        requests through the classical text-marker path instead.
+
+        Subclasses that support structured output override this method to
+        inject the provider-specific field (``response_format`` for
+        OpenAI-compatible APIs, ``generationConfig.responseMimeType`` +
+        ``responseSchema`` for Gemini, ...).
+
+        :schema: an optional JSON Schema dict describing the expected
+            response shape. Engines that support ``'schema'`` should
+            enforce it; engines that only support ``'json'`` may ignore
+            it and rely on prompt engineering to produce the right shape.
+        """
+        return self.get_body(text)
+
     def override_prompt(self, prompt_text):
         if not hasattr(self, '_prompt_stash'):
             self._prompt_stash = self.prompt

--- a/engines/genai.py
+++ b/engines/genai.py
@@ -15,6 +15,39 @@ class GenAI(Base, ABC):
     top_p: float
     top_k: int
 
+    # Marker consumed by the novel translation pipeline (lib/novel.py) and
+    # by the UI: only engines that expose an LLM chat interface should be
+    # eligible for novel mode, since it relies on a system prompt carrying
+    # a running summary and glossary. Non-GenAI engines (Google, DeepL, ...)
+    # leave this at False on ``Base``.
+    supports_novel_mode: bool = True
+
     @abstractmethod
     def get_models(self) -> list[str]:
         """Automatically get the models for the engine."""
+
+    # ------------------------------------------------------------------
+    # Novel mode support: transient prompt override.
+    # ------------------------------------------------------------------
+    #
+    # The default paragraph-per-request pipeline uses ``self.prompt`` as the
+    # system prompt for every call. The novel pipeline instead wants to
+    # inject a *different* system prompt for each request (containing the
+    # running summary and the dynamic glossary) without permanently mutating
+    # the engine configuration.
+    #
+    # ``override_prompt`` saves the current prompt (once, so nested calls
+    # remain safe) and swaps in the new one; ``restore_prompt`` puts the
+    # original prompt back. Sub-classes that build the message payload from
+    # ``self.prompt`` (ChatGPT, Claude, Gemini) do not need any further
+    # change: they will naturally pick up the overridden value.
+
+    def override_prompt(self, prompt_text):
+        if not hasattr(self, '_prompt_stash'):
+            self._prompt_stash = self.prompt
+        self.prompt = prompt_text
+
+    def restore_prompt(self):
+        if hasattr(self, '_prompt_stash'):
+            self.prompt = self._prompt_stash
+            del self._prompt_stash

--- a/engines/google.py
+++ b/engines/google.py
@@ -331,6 +331,8 @@ class GeminiTranslate(GenAI):
     request_interval: float = 1.0
     request_timeout: float = 30.0
 
+    structured_output_mode = 'schema'
+
     prompt = (
         'You are a meticulous translator who translates any given content. '
         'Translate the given content from <slang> to <tlang> only. Do not '
@@ -403,8 +405,6 @@ class GeminiTranslate(GenAI):
                 {"role": "user", "parts": [{"text": self._prompt(text)}]},
             ],
             "generationConfig": {
-                # "stopSequences": ["Test"],
-                # "maxOutputTokens": 2048,
                 "temperature": self.temperature,
                 "topP": self.top_p,
                 "topK": self.top_k,
@@ -428,6 +428,21 @@ class GeminiTranslate(GenAI):
                 },
             ],
         })
+
+    def get_body_for_structured(self, text, schema=None):
+        """Return the request body with Gemini's native JSON output.
+
+        Uses ``generationConfig.responseMimeType = 'application/json'``
+        and optionally ``responseSchema`` for strict enforcement. See:
+        https://ai.google.dev/gemini-api/docs/structured-output
+        """
+        body = json.loads(self.get_body(text))
+        gen_config = body.get('generationConfig', {})
+        gen_config['responseMimeType'] = 'application/json'
+        if schema:
+            gen_config['responseSchema'] = schema
+        body['generationConfig'] = gen_config
+        return json.dumps(body)
 
     def get_result(self, response):
         if self.stream:

--- a/engines/openai.py
+++ b/engines/openai.py
@@ -32,6 +32,8 @@ class ChatgptTranslate(GenAI):
     request_interval = 20.0
     request_timeout = 60.0
 
+    structured_output_mode = 'schema'
+
     prompt = (
         'You are a meticulous translator who translates any given content. '
         'Translate the given content from <slang> to <tlang> only. Do not '
@@ -102,6 +104,51 @@ class ChatgptTranslate(GenAI):
             body.update(stream=True)
         sampling_value = getattr(self, self.sampling)
         body.update({self.sampling: sampling_value})
+        body['reasoning_effort'] = 'none'
+        return json.dumps(body)
+
+    def get_body_for_structured(self, text, schema=None):
+        """Return the request body with structured (JSON) output enabled.
+
+        Uses OpenAI's ``response_format`` field, honored by:
+          * OpenAI itself (with ``type: json_schema`` since GPT-4o).
+          * Ollama's OpenAI-compatible endpoint (accepts both
+            ``type: json_object`` and ``type: json_schema``).
+          * Other OpenAI-compatible servers (LM Studio, vLLM, ...).
+
+        Streaming is kept enabled (``stream: true``) so that long
+        responses (80+ translated paragraphs) are delivered token by
+        token without hitting the client-side request timeout. The
+        caller is responsible for collecting all SSE chunks and
+        assembling the complete JSON string before parsing (see
+        ``NovelTranslator._translate_with_retry_structured``).
+
+        ``reasoning_effort: none`` is set for the same reason as in
+        :meth:`get_body`: reasoning tokens make structured output
+        responses very slow and do not improve translation quality.
+        """
+        body: dict[str, Any] = {
+            'model': self.model,
+            'messages': [
+                {'role': 'system', 'content': self.get_prompt()},
+                {'role': 'user', 'content': text}
+            ],
+            'stream': True,           # keep streaming to avoid client-timeout
+            'reasoning_effort': 'none',  # disable CoT reasoning tokens
+        }
+        sampling_value = getattr(self, self.sampling)
+        body.update({self.sampling: sampling_value})
+        if schema:
+            body['response_format'] = {
+                'type': 'json_schema',
+                'json_schema': {
+                    'name': 'novel_translation',
+                    'schema': schema,
+                    'strict': True,
+                },
+            }
+        else:
+            body['response_format'] = {'type': 'json_object'}
         return json.dumps(body)
 
     def get_result(self, response):

--- a/lib/config.py
+++ b/lib/config.py
@@ -46,6 +46,24 @@ defaults: dict[str, Any] = {
     'merge_length': 1800,
     'ebook_metadata': {},
     'search_paths': [],
+    # Novel Mode: LLM-only sequential pipeline with running summary + dynamic
+    # glossary. See lib/novel.py for details. Prompts default to None so the
+    # runtime falls back to the templates defined in lib/novel.py; users can
+    # override them from the Setting dialog.
+    'novel_mode_enabled': False,
+    'novel_chunk_tokens': 8000,
+    'novel_context_tokens': 1500,
+    'novel_summary_tokens': 400,
+    'novel_glossary_max_entries': 200,
+    # Chapters with fewer translated characters than this threshold are
+    # translated normally but skip the summary + glossary extraction
+    # LLM calls. Typical target: front/back matter (Copyright, Table of
+    # Contents, About the Author, ...) which is not narrative content.
+    'novel_min_chars_for_context': 300,
+    'novel_chapter_source': 'toc_level_1',  # 'toc_level_1' | 'xhtml_file'
+    'novel_translation_prompt': None,
+    'novel_summary_prompt': None,
+    'novel_glossary_prompt': None,
 }
 
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -46,19 +46,18 @@ defaults: dict[str, Any] = {
     'merge_length': 1800,
     'ebook_metadata': {},
     'search_paths': [],
-    # Novel Mode: LLM-only sequential pipeline with running summary + dynamic
-    # glossary. See lib/novel.py for details. Prompts default to None so the
-    # runtime falls back to the templates defined in lib/novel.py; users can
-    # override them from the Setting dialog.
     'novel_mode_enabled': False,
     'novel_chunk_tokens': 12000,
-    # Maximum number of translatable paragraphs per chunk. Dual-cap
-    # chunking closes a chunk when EITHER the token budget above OR this
-    # paragraph count is reached -- whichever comes first. Prevents the
-    # LLM from losing track of <Pn>...</Pn> alignment markers on short
-    # paragraphs (dialogue, TOC lists). Set to 0 to disable and rely
-    # exclusively on the token budget.
-    'novel_max_paragraphs_per_chunk': 60,
+    'novel_max_paragraphs_per_chunk': 80,
+    # Structured output policy for the novel translator.
+    #   'auto'  -> use JSON structured output when the engine advertises
+    #              support (see engines.genai.GenAI.structured_output_mode),
+    #              otherwise fall back to text markers [N]. Default.
+    #   'off'   -> always use text markers, even on capable engines.
+    #   'force' -> always use JSON structured output, even on engines that
+    #              don't advertise it
+    'novel_structured_output': 'auto',
+    'novel_overlap_paragraphs': 3,
     'novel_context_tokens': 1500,
     'novel_summary_tokens': 400,
     'novel_glossary_max_entries': 200,
@@ -67,7 +66,11 @@ defaults: dict[str, Any] = {
     # LLM calls. Typical target: front/back matter (Copyright, Table of
     # Contents, About the Author, ...) which is not narrative content.
     'novel_min_chars_for_context': 300,
-    'novel_chapter_source': 'toc_level_1',  # 'toc_level_1' | 'xhtml_file'
+    'novel_chapter_source': 'toc_level_1',  # 'toc_level_1' | 'toc_level_2' | 'xhtml_file'
+    # Pages whose total non-ignored text (in chars) is below this threshold
+    # are treated as front/back matter (Cover, Titlepage, decorative pages)
+    # and excluded from chapter narrative content. Set to 0 to disable.
+    'novel_front_matter_min_chars': 100,
     'novel_translation_prompt': None,
     'novel_summary_prompt': None,
     'novel_glossary_prompt': None,

--- a/lib/config.py
+++ b/lib/config.py
@@ -51,7 +51,14 @@ defaults: dict[str, Any] = {
     # runtime falls back to the templates defined in lib/novel.py; users can
     # override them from the Setting dialog.
     'novel_mode_enabled': False,
-    'novel_chunk_tokens': 8000,
+    'novel_chunk_tokens': 12000,
+    # Maximum number of translatable paragraphs per chunk. Dual-cap
+    # chunking closes a chunk when EITHER the token budget above OR this
+    # paragraph count is reached -- whichever comes first. Prevents the
+    # LLM from losing track of <Pn>...</Pn> alignment markers on short
+    # paragraphs (dialogue, TOC lists). Set to 0 to disable and rely
+    # exclusively on the token budget.
+    'novel_max_paragraphs_per_chunk': 60,
     'novel_context_tokens': 1500,
     'novel_summary_tokens': 400,
     'novel_glossary_max_entries': 200,

--- a/lib/conversion.py
+++ b/lib/conversion.py
@@ -478,7 +478,9 @@ def convert_item_novel(
 
     config = get_config()
     novel_config = {
-        'novel_chunk_tokens': config.get('novel_chunk_tokens', 8000),
+        'novel_chunk_tokens': config.get('novel_chunk_tokens', 12000),
+        'novel_max_paragraphs_per_chunk': config.get(
+            'novel_max_paragraphs_per_chunk', 60),
         'novel_context_tokens': config.get('novel_context_tokens', 1500),
         'novel_summary_tokens': config.get('novel_summary_tokens', 400),
         'novel_glossary_max_entries': config.get(

--- a/lib/conversion.py
+++ b/lib/conversion.py
@@ -436,7 +436,7 @@ def get_novel_config():
     return {
         'novel_chunk_tokens': config.get('novel_chunk_tokens', 12000),
         'novel_max_paragraphs_per_chunk': config.get(
-            'novel_max_paragraphs_per_chunk', 20),
+            'novel_max_paragraphs_per_chunk', 80),
         'novel_overlap_paragraphs': config.get(
             'novel_overlap_paragraphs', 3),
         'novel_structured_output': config.get(

--- a/lib/conversion.py
+++ b/lib/conversion.py
@@ -24,6 +24,8 @@ from .element import (
     get_element_handler, get_srt_elements, get_toc_elements, get_page_elements,
     get_metadata_elements, get_pgn_elements)
 from .translation import get_translator, get_translation
+from .novel import (
+    ChapterBuilder, ContextManager, NovelTranslator, novel_cache_id)
 from .exception import ConversionAbort
 
 
@@ -72,6 +74,178 @@ def convert_book(
 
         paragraphs = cache.all_paragraphs()
         translation.handle(paragraphs)
+        element_handler.add_translations(paragraphs)
+
+        log.info(sep())
+        log.info(_('Start to convert ebook format...'))
+        log.info(sep())
+
+        self.report_progress = CompositeProgressReporter(
+            backup_progress, 1, notification)
+        self.report_progress(0., _('Outputting ebook file...'))
+        _convert(oeb, output_path, input_plugin, opts, log)
+
+    plumber.output_plugin.convert = MethodType(convert, plumber.output_plugin)
+    plumber.run()
+
+
+def convert_book_novel(
+        input_path, output_path, translator, element_handler, cache,
+        debug_info, encoding, notification,
+        chapter_source='toc_level_1',
+        novel_config=None,
+        log_callback=None,
+        progress_callback=None,
+        cancel_request=None,
+        chapter_started=None,
+        chapter_done=None,
+        cache_only=False) -> None:
+    """Novel-mode variant of ``convert_book``.
+
+    Translates the book sequentially, chapter-by-chapter, maintaining a
+    running summary + glossary through a ``ContextManager`` persisted in the
+    same SQLite cache. Metadata and TOC titles are translated with the
+    classic single-shot pipeline (they are not narrative content) so this
+    function accepts a *translator* rather than the wrapped ``Translation``
+    orchestrator used by ``convert_book``.
+
+    :translator: an already-configured engine instance (source_lang,
+        target_lang and merge_enabled must be set by the caller). Only
+        GenAI-compatible engines make sense here.
+    :chapter_source: strategy passed to ``ChapterBuilder`` ('toc_level_1'
+        or 'xhtml_file').
+    :novel_config: dict of ``novel_*`` config keys read from
+        ``lib.config.get_config``.
+    :log_callback: callable(str, bool=False). Logging function reused by
+        the UI (mirrors ``lib.translation.Translation.set_logging``).
+    :progress_callback: callable(float 0..1, str message).
+    :cancel_request: callable() -> bool. If True, the pipeline raises
+        ``TranslationCanceled`` at the next safe point.
+    :chapter_started / chapter_done: UI callbacks (see NovelTranslator).
+    :cache_only: If True, do NOT translate anything. Just use existing
+        translations from the SQLite cache to rebuild the output ebook.
+        This is the mode used by the UI "Build translated ebook" button
+        after the user has already run the pipeline interactively.
+    """
+    log_callback = log_callback or (lambda *a, **k: None)
+    progress_callback = progress_callback or (lambda *a, **k: None)
+    cancel_request = cancel_request or (lambda: False)
+
+    plumber = Plumber(
+        input_path, output_path, log=log, report_progress=notification)
+    _convert = plumber.output_plugin.convert
+    elements = []
+
+    def convert(self, oeb, output_path, input_plugin, opts, log):
+        backup_progress = self.report_progress.global_min
+        self.report_progress = CompositeProgressReporter(0, 1, notification)
+        log.info('Translating ebook content in novel mode...')
+        log.info(debug_info)
+
+        # 1. Extract elements exactly like the classic pipeline. Novel mode
+        #    still relies on the same DOM handler for TOC/metadata and
+        #    for reinserting the translated paragraphs at the end.
+        elements.extend(get_metadata_elements(oeb.metadata))
+        elements.extend(get_toc_elements(oeb.toc.nodes, []))
+        elements.extend(get_page_elements(oeb.manifest.items))
+        original_group = element_handler.prepare_original(elements)
+        # ``save`` is idempotent: it only writes when the cache is fresh.
+        cache.save(original_group)
+
+        paragraphs = cache.all_paragraphs()
+
+        if cache_only:
+            # Cache-only path: the UI already ran the translation pipeline
+            # interactively and populated the cache. We just need to inject
+            # the existing translations back into the DOM and let Plumber
+            # emit the output ebook. Do NOT invoke the LLM at all.
+            log_callback(_(
+                'Novel mode (cache-only): reusing {} cached paragraph(s).')
+                .format(len(paragraphs)))
+        else:
+            # 2. Compute the ordered spine (xhtml pages only) so
+            #    ChapterBuilder can walk the book in reading order. Reuse
+            #    the same key as ``Extraction.get_sorted_pages`` for
+            #    consistency.
+            import re as _re
+            from .utils import sorted_mixed_keys
+            page_pattern = _re.compile(r'\.(xhtml|html|htm|xml|xht)$')
+            xhtml_items = [item for item in oeb.manifest.items
+                           if page_pattern.search(item.href or '')]
+            xhtml_items.sort(
+                key=lambda item: sorted_mixed_keys(item.href or ''))
+            ordered_page_ids = [item.id for item in xhtml_items]
+
+            # 3. Build chapters.
+            builder = ChapterBuilder(
+                ordered_page_ids, oeb.toc.nodes,
+                list(oeb.manifest.items), paragraphs,
+                source=chapter_source)
+            chapters = builder.build()
+            log_callback(
+                _('Novel mode: {} chapter(s) detected.')
+                .format(len(chapters)))
+
+            # 4. Load the context manager (summaries + glossary + progress).
+            ctx = ContextManager(
+                cache,
+                glossary_max_entries=int(
+                    (novel_config or {}).get(
+                        'novel_glossary_max_entries', 200) or 0),
+            ).load()
+
+            # 5. Non-chapter paragraphs (metadata, TOC titles): translate
+            #    them with the classic single-shot translator so the
+            #    resulting ebook is not stuck with English titles /
+            #    metadata.
+            aux_paragraphs = [
+                p for p in paragraphs
+                if p.page in ChapterBuilder.AUX_PAGES
+                and not p.ignored and not p.translation]
+            if aux_paragraphs:
+                log_callback(
+                    _('Novel mode: translating {} auxiliary item(s) '
+                      '(metadata/TOC).').format(len(aux_paragraphs)))
+                for para in aux_paragraphs:
+                    if cancel_request():
+                        from .exception import TranslationCanceled
+                        raise TranslationCanceled(
+                            _('Translation canceled.'))
+                    try:
+                        if hasattr(translator, 'restore_prompt'):
+                            translator.restore_prompt()
+                        text = translator.translate(para.original)
+                        if hasattr(text, '__iter__') and not isinstance(
+                                text, str):
+                            text = ''.join(text)
+                        para.translation = (text or '').strip()
+                        para.engine_name = translator.name
+                        para.target_lang = (
+                            translator.get_target_lang()
+                            if hasattr(translator, 'get_target_lang')
+                            else getattr(translator, 'target_lang', None))
+                        cache.update_paragraph(para)
+                    except Exception as exc:
+                        log_callback(
+                            _('Auxiliary translation failed for id={}: {}')
+                            .format(para.id, exc), True)
+
+            # 6. Run the novel translator on chapter content.
+            novel_translator = NovelTranslator(
+                translator, chapters, ctx, cache,
+                config=novel_config or {})
+            novel_translator.set_logging(log_callback)
+            novel_translator.set_progress(progress_callback)
+            novel_translator.set_cancel_request(cancel_request)
+            if chapter_started is not None:
+                novel_translator.set_chapter_started(chapter_started)
+            if chapter_done is not None:
+                novel_translator.set_chapter_done(chapter_done)
+            novel_translator.run()
+
+        # 7. Reload paragraphs from cache (they were mutated during
+        #    translation via update_paragraph) and reinject into the DOM.
+        paragraphs = cache.all_paragraphs()
         element_handler.add_translations(paragraphs)
 
         log.info(sep())
@@ -246,6 +420,93 @@ def convert_item(
     cache.done()
 
 
+def convert_item_novel(
+        ebook_title, input_path, output_path, source_lang, target_lang,
+        cache_only, format, encoding, direction, notification):
+    """Novel-mode variant of ``convert_item``.
+
+    Kept as a *separate* function (rather than a flag on ``convert_item``)
+    because Calibre's ``arbitrary_n`` job runner injects ``notification`` as
+    the last positional argument of the callable. Adding any parameter
+    between ``direction`` and ``notification`` would collide with that
+    convention and raise "multiple values for argument 'notification'".
+
+    :cache_only: If True, do NOT invoke the LLM. Reuse the cache populated
+        by the interactive UI (``NovelTranslation`` dialog) and only rebuild
+        the output ebook via Plumber. This is the mode used by the
+        "Build translated ebook" button.
+    """
+    if format in extra_formats:
+        raise Exception(
+            _('Novel mode is not supported for {} files.').format(format))
+
+    translator = get_translator()
+    translator.set_source_lang(source_lang)
+    translator.set_target_lang(target_lang)
+
+    element_handler = get_element_handler(
+        translator.placeholder, translator.separator, direction)
+    element_handler.set_translation_lang(
+        translator.get_iso639_target_code(target_lang))
+
+    _encoding = ''
+    if encoding.lower() != 'utf-8':
+        _encoding = encoding.lower()
+    cache_id = novel_cache_id(
+        input_path, translator.name, target_lang, _encoding)
+    cache = get_cache(cache_id)
+    cache.set_cache_only(cache_only)
+    cache.set_info('title', ebook_title)
+    cache.set_info('engine_name', translator.name)
+    cache.set_info('target_lang', target_lang)
+    cache.set_info('plugin_version', EbookTranslator.__version__)
+    cache.set_info('calibre_version', __version__)
+    cache.set_info('novel_mode', '1')
+
+    debug_info = '{0}\n| Diagnosis Information\n{0}'.format(sep())
+    debug_info += '\n| Calibre Version: %s\n' % __version__
+    debug_info += '| Plugin Version: %s\n' % EbookTranslator.__version__
+    debug_info += '| Translation Engine: %s\n' % translator.name
+    debug_info += '| Source Language: %s\n' % source_lang
+    debug_info += '| Target Language: %s\n' % target_lang
+    debug_info += '| Encoding: %s\n' % encoding
+    debug_info += '| Cache Enabled: %s\n' % cache.is_persistence()
+    debug_info += '| Cache-only: %s\n' % ('yes' if cache_only else 'no')
+    debug_info += '| Novel Mode: yes\n'
+    debug_info += '| Input Path: %s\n' % input_path
+    debug_info += '| Output Path: %s' % output_path
+
+    config = get_config()
+    novel_config = {
+        'novel_chunk_tokens': config.get('novel_chunk_tokens', 8000),
+        'novel_context_tokens': config.get('novel_context_tokens', 1500),
+        'novel_summary_tokens': config.get('novel_summary_tokens', 400),
+        'novel_glossary_max_entries': config.get(
+            'novel_glossary_max_entries', 200),
+        'novel_min_chars_for_context': config.get(
+            'novel_min_chars_for_context', 300),
+        'novel_translation_prompt': config.get(
+            'novel_translation_prompt', None),
+        'novel_summary_prompt': config.get(
+            'novel_summary_prompt', None),
+        'novel_glossary_prompt': config.get(
+            'novel_glossary_prompt', None),
+    }
+    chapter_source = config.get(
+        'novel_chapter_source', 'toc_level_1') or 'toc_level_1'
+
+    convert_book_novel(
+        input_path, output_path, translator, element_handler, cache,
+        debug_info, encoding, notification,
+        chapter_source=chapter_source,
+        novel_config=novel_config,
+        log_callback=lambda text, error=False: log.info(text),
+        progress_callback=notification,
+        cache_only=cache_only,
+    )
+    cache.done()
+
+
 class ConversionWorker:
     def __init__(self, gui, icon):
         self.gui = gui
@@ -278,6 +539,39 @@ class ConversionWorker:
                  ebook.target_lang, cache_only, is_batch, ebook.input_format,
                  ebook.encoding, ebook.target_direction)),
             description=(_('[{} > {}] Translating "{}"').format(
+                ebook.source_lang, ebook.target_lang, ebook.title)))
+        self.working_jobs[job] = (ebook, output_path)
+
+    def translate_ebook_novel(self, ebook, cache_only=True):
+        """Launch a novel-mode job.
+
+        Typically used only with ``cache_only=True`` to rebuild the output
+        ebook after the interactive novel-mode UI has already populated
+        the cache. Uses a dedicated ``convert_item_novel`` entry point so
+        it does not conflict with the classic pipeline's positional args.
+        """
+        input_path = ebook.get_input_path()
+        if not self.config.get('to_library'):
+            filename = sanitize_file_name(ebook.title[:200])
+            output_path = self.config.get('output_path')
+            if output_path is None or not os.path.isdir(output_path):
+                raise Exception(
+                    _('Please set a valid output path.'))
+            output_path = os.path.join(
+                output_path, f'{filename}.{ebook.output_format}')
+        else:
+            output_path = PersistentTemporaryFile(
+                suffix='.' + ebook.output_format).name
+        job = self.gui.job_manager.run_job(
+            Dispatcher(self.translate_done),
+            'arbitrary_n',
+            args=(
+                'calibre_plugins.ebook_translator.lib.conversion',
+                'convert_item_novel',
+                (ebook.title, input_path, output_path, ebook.source_lang,
+                 ebook.target_lang, cache_only, ebook.input_format,
+                 ebook.encoding, ebook.target_direction)),
+            description=(_('[{} > {}] Building novel "{}"').format(
                 ebook.source_lang, ebook.target_lang, ebook.title)))
         self.working_jobs[job] = (ebook, output_path)
 

--- a/lib/conversion.py
+++ b/lib/conversion.py
@@ -180,7 +180,10 @@ def convert_book_novel(
             builder = ChapterBuilder(
                 ordered_page_ids, oeb.toc.nodes,
                 list(oeb.manifest.items), paragraphs,
-                source=chapter_source)
+                source=chapter_source,
+                front_matter_min_chars=int(
+                    (novel_config or {}).get(
+                        'novel_front_matter_min_chars', 100) or 0))
             chapters = builder.build()
             log_callback(
                 _('Novel mode: {} chapter(s) detected.')
@@ -420,6 +423,43 @@ def convert_item(
     cache.done()
 
 
+def get_novel_config():
+    """Return a dict of all ``novel_*`` settings read from the plugin config.
+
+    Single source of truth for the novel-mode configuration dict. Both
+    the interactive UI worker (``NovelTranslationWorker`` in ``novel.py``)
+    and the background job entry point (``convert_item_novel``) call this
+    function so that any future additions to the config surface
+    automatically in both code paths without risking drift.
+    """
+    config = get_config()
+    return {
+        'novel_chunk_tokens': config.get('novel_chunk_tokens', 12000),
+        'novel_max_paragraphs_per_chunk': config.get(
+            'novel_max_paragraphs_per_chunk', 20),
+        'novel_overlap_paragraphs': config.get(
+            'novel_overlap_paragraphs', 3),
+        'novel_structured_output': config.get(
+            'novel_structured_output', 'auto'),
+        'novel_front_matter_min_chars': config.get(
+            'novel_front_matter_min_chars', 100),
+        'novel_context_tokens': config.get('novel_context_tokens', 1500),
+        'novel_summary_tokens': config.get('novel_summary_tokens', 400),
+        'novel_glossary_max_entries': config.get(
+            'novel_glossary_max_entries', 200),
+        'novel_min_chars_for_context': config.get(
+            'novel_min_chars_for_context', 300),
+        'novel_summary_input_max_chars': config.get(
+            'novel_summary_input_max_chars', 12000),
+        'novel_translation_prompt': config.get(
+            'novel_translation_prompt', None),
+        'novel_summary_prompt': config.get(
+            'novel_summary_prompt', None),
+        'novel_glossary_prompt': config.get(
+            'novel_glossary_prompt', None),
+    }
+
+
 def convert_item_novel(
         ebook_title, input_path, output_path, source_lang, target_lang,
         cache_only, format, encoding, direction, notification):
@@ -476,25 +516,8 @@ def convert_item_novel(
     debug_info += '| Input Path: %s\n' % input_path
     debug_info += '| Output Path: %s' % output_path
 
-    config = get_config()
-    novel_config = {
-        'novel_chunk_tokens': config.get('novel_chunk_tokens', 12000),
-        'novel_max_paragraphs_per_chunk': config.get(
-            'novel_max_paragraphs_per_chunk', 60),
-        'novel_context_tokens': config.get('novel_context_tokens', 1500),
-        'novel_summary_tokens': config.get('novel_summary_tokens', 400),
-        'novel_glossary_max_entries': config.get(
-            'novel_glossary_max_entries', 200),
-        'novel_min_chars_for_context': config.get(
-            'novel_min_chars_for_context', 300),
-        'novel_translation_prompt': config.get(
-            'novel_translation_prompt', None),
-        'novel_summary_prompt': config.get(
-            'novel_summary_prompt', None),
-        'novel_glossary_prompt': config.get(
-            'novel_glossary_prompt', None),
-    }
-    chapter_source = config.get(
+    novel_config = get_novel_config()
+    chapter_source = get_config().get(
         'novel_chapter_source', 'toc_level_1') or 'toc_level_1'
 
     convert_book_novel(

--- a/lib/element.py
+++ b/lib/element.py
@@ -351,8 +351,7 @@ class PageElement(Element):
                 if attr == 'text':
                     elem.text = part if part else None
                 else:
-                    # Preserve surrounding whitespace for tails.
-                    elem.tail = (' ' + part) if part else (elem.tail or '')
+                    elem.tail = (' ' + part) if part else None
 
             # Apply translation attributes.
             cloned.set('dir', self.target_direction or 'auto')

--- a/lib/element.py
+++ b/lib/element.py
@@ -266,6 +266,105 @@ class PageElement(Element):
             new_element.set('style', 'color:%s' % self.translation_color)
         return new_element
 
+    def _has_structural_links(self):
+        """Return True if the element contains nested <a href> or named
+        anchors that should survive a position='only' translation.
+
+        These are the link targets / navigation links that connect the
+        in-page Table of Contents to chapter headings.  Losing them in
+        'only' mode makes the TOC non-functional.
+        """
+        for child in self.element.iter():
+            tag = getattr(child, 'tag', None)
+            if tag is None:
+                continue
+            local = etree.QName(tag).localname if '{' in str(tag) else tag
+            if local == 'a':
+                if child.get('href') or child.get('name') or child.get('id'):
+                    return True
+        return False
+
+    def _clone_with_translation(self, translation):
+        """Return a deep clone of the original element where the leaf text
+        nodes have been replaced by the translated text, while all child
+        elements (and crucially their attributes such as href, id, name)
+        are preserved.
+
+        Strategy
+        --------
+        1. Deep-copy the original element.
+        2. Collect all leaf text content (text + tail of each child) in
+           document order.
+        3. Split the translation into the same number of parts by trying
+           to match the original text distribution; fall back to putting
+           all text in the first leaf if the split does not work out.
+        4. Rewrite the text/tail nodes in the clone.
+        5. Apply the standard translation attributes (dir, lang, style).
+
+        This is intentionally conservative: if anything goes wrong the
+        caller falls back to the normal (flat) new_element path.
+        """
+        try:
+            import copy as _copy
+            cloned = _copy.deepcopy(self.element)
+
+            # Collect leaf text positions in document order.
+            # A "position" is (element_ref, 'text'|'tail').
+            positions = []
+            root_text = (cloned.text or '').strip()
+            if root_text:
+                positions.append((cloned, 'text'))
+            for child in cloned.iter():
+                if child is cloned:
+                    continue
+                if (child.text or '').strip():
+                    positions.append((child, 'text'))
+                if (child.tail or '').strip():
+                    positions.append((child, 'tail'))
+
+            if not positions:
+                return None
+
+            # Split translation into parts matching the number of positions.
+            translation_stripped = translation.strip()
+            if len(positions) == 1:
+                parts = [translation_stripped]
+            else:
+                parts = [p.strip()
+                         for p in translation_stripped.splitlines()
+                         if p.strip()]
+                if len(parts) != len(positions):
+                    # Fallback: put all translated text in the first
+                    # position (root text or first child text) and clear
+                    # the rest. This is safe because the link hrefs and
+                    # structural children are preserved regardless.
+                    parts = [translation_stripped] + [''] * (
+                        len(positions) - 1)
+
+            # Pad or truncate to match.
+            while len(parts) < len(positions):
+                parts.append('')
+            parts = parts[:len(positions)]
+
+            # Rewrite text nodes in the clone.
+            for (elem, attr), part in zip(positions, parts):
+                if attr == 'text':
+                    elem.text = part if part else None
+                else:
+                    # Preserve surrounding whitespace for tails.
+                    elem.tail = (' ' + part) if part else (elem.tail or '')
+
+            # Apply translation attributes.
+            cloned.set('dir', self.target_direction or 'auto')
+            if self.translation_lang is not None:
+                cloned.set('lang', self.translation_lang)
+            if self.translation_color is not None:
+                cloned.set('style', 'color:%s' % self.translation_color)
+
+            return cloned
+        except Exception:
+            return None
+
     def add_translation(self, translation=None):
         # self.element.tail = None  # Make sure the element has no tail
         if self.original_color is not None:
@@ -306,6 +405,17 @@ class PageElement(Element):
         group_elements = ('li', 'th', 'td', 'caption')
         if element_name in group_elements:
             if self.position == 'only':
+                # Same structure-aware logic as the general path below:
+                # preserve nested links inside <li> items (TOC lists).
+                if self._has_structural_links():
+                    import html as _html
+                    plain_translation = _html.unescape(translation)
+                    cloned = self._clone_with_translation(plain_translation)
+                    if cloned is not None:
+                        cloned.tail = self.element.tail
+                        self.element.addnext(cloned)
+                        self._safe_remove(self.element)
+                        return
                 self.element.addnext(new_element)
                 self._safe_remove(self.element)
             new_element = self._create_new_element(
@@ -362,6 +472,30 @@ class PageElement(Element):
             get_name(parent_element) in group_elements
 
         if self.position == 'only':
+            # Structure-aware replacement: if the element contains nested
+            # links (<a href>, named anchors) we clone the original
+            # structure and replace only the text nodes, so TOC links and
+            # in-page navigation survive the translation.  This prevents
+            # the loss of hyperlinks that is otherwise observed when the
+            # translated content is a plain text string reconstructed from
+            # scratch (see _create_new_element which strips all child
+            # markup). Fall back to the flat replacement if the clone
+            # cannot be built (empty element, unexpected structure, etc.).
+            if self._has_structural_links():
+                # Unescape the xml_escape() applied earlier so the clone
+                # receives readable text, not HTML entities.
+                import html as _html
+                plain_translation = _html.unescape(translation)
+                cloned = self._clone_with_translation(plain_translation)
+                if cloned is not None:
+                    # Preserve the tail of the original element on the
+                    # clone so surrounding whitespace is not lost.
+                    cloned.tail = self.element.tail
+                    self.element.addnext(cloned)
+                    self._safe_remove(self.element)
+                    return
+            # Default flat replacement (no structural links, or clone
+            # failed): insert new_element and remove the original.
             self.element.addnext(new_element)
             self._safe_remove(self.element)
             return

--- a/lib/novel.py
+++ b/lib/novel.py
@@ -1,0 +1,1347 @@
+"""Novel Mode: chapter-aware sequential translation pipeline for LLMs.
+
+This module implements a dedicated translation pipeline optimized for narrative
+long-form content (novels). Unlike the default paragraph-by-paragraph parallel
+pipeline (see ``lib/translation.py``), the novel pipeline:
+
+  * groups paragraphs by chapter, using the ebook Table of Contents when
+    available (fallback: one XHTML file per chapter);
+  * translates chapters sequentially, one after the other, without concurrency;
+  * chunks each chapter to fit an LLM token budget (default ~8k) without ever
+    splitting a paragraph in half;
+  * maintains a running summary of previously translated chapters, injected
+    into each translation prompt so the model preserves narrative continuity;
+  * maintains a dynamic glossary of characters, places and other named
+    entities extracted after each chapter, kept consistent across the book;
+  * persists progress, summaries and glossary in the existing SQLite cache
+    (via the ``info`` key/value table -- no schema change) so an interrupted
+    translation can be resumed from the last completed chapter.
+
+The public entry points are:
+
+    ChapterBuilder(oeb, paragraphs, config).build() -> list[Chapter]
+    TokenBudget(budget).chunk(paragraphs, reserved) -> list[list[Paragraph]]
+    ContextManager(cache).load() / append_chapter() / context_text()
+    NovelTranslator(translator, chapters, context_manager, cache, config).run()
+
+This module has no direct dependency on Qt so it is fully unit-testable.
+"""
+
+import re
+import json
+import time
+
+from calibre.utils.localization import _  # type: ignore
+
+from .utils import log, sep, uid, dummy
+from .exception import TranslationCanceled, TranslationFailed
+
+
+load_translations()  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Chapter model
+# ---------------------------------------------------------------------------
+
+
+class Chapter:
+    """A logical chapter of the book.
+
+    A chapter groups one or more page_ids together with the list of already
+    extracted Paragraphs that belong to those pages. The ``index`` is 1-based
+    and matches the order of the chapter inside the book (spine order).
+    """
+
+    def __init__(self, index, title, page_ids, paragraphs):
+        self.index = index
+        self.title = title or ''
+        self.page_ids = list(page_ids)
+        self.paragraphs = list(paragraphs)
+
+    @property
+    def char_count(self):
+        return sum(len(p.original or '') for p in self.paragraphs
+                   if not p.ignored)
+
+    def translatable_paragraphs(self):
+        return [p for p in self.paragraphs if not p.ignored]
+
+    def __repr__(self):
+        return ('Chapter(index=%s, title=%r, page_ids=%s, paragraphs=%d)'
+                % (self.index, self.title, self.page_ids,
+                   len(self.paragraphs)))
+
+
+# ---------------------------------------------------------------------------
+# Chapter builder
+# ---------------------------------------------------------------------------
+
+
+def _href_to_page_id(href, manifest_items):
+    """Map an href (as found in TOC nodes) to a manifest item id.
+
+    TOC hrefs often contain a fragment (``chap1.xhtml#section-2``) which must
+    be stripped before comparing with the manifest item href.
+    """
+    if not href:
+        return None
+    clean = href.split('#', 1)[0]
+    # Try exact match first.
+    for item in manifest_items:
+        if getattr(item, 'href', None) == clean:
+            return item.id
+    # Fallback: match by basename (some TOCs use relative paths).
+    base = clean.rsplit('/', 1)[-1]
+    for item in manifest_items:
+        item_href = getattr(item, 'href', '') or ''
+        if item_href.rsplit('/', 1)[-1] == base:
+            return item.id
+    return None
+
+
+class ChapterBuilder:
+    """Build ``Chapter`` objects from an OEB book and a flat paragraph list.
+
+    Strategy:
+
+    1. Determine the ordered list of "page ids" (the spine order used by the
+       existing extraction pipeline: ``manifest.items`` filtered to xhtml
+       and sorted by ``sorted_mixed_keys``).
+    2. Determine chapter boundaries. Preference order:
+         a. Top-level TOC nodes (level 1 only) if the TOC has 2+ nodes.
+         b. Otherwise fall back to "one xhtml file == one chapter".
+    3. Group paragraphs by (or between) those boundaries. Any paragraphs
+       whose ``page`` id does not belong to any chapter range are attached
+       to the closest previous chapter (typically front matter appended to
+       chapter 1) so nothing is silently dropped.
+
+    Only paragraphs coming from XHTML pages are considered as chapter
+    content. Metadata and TOC paragraphs (page_id ``content.opf`` / ``toc.ncx``)
+    are collected separately in ``self.aux_paragraphs`` so callers can decide
+    what to do with them -- typically translated via the classic pipeline,
+    keeping the novel pipeline focused on narrative content.
+    """
+
+    AUX_PAGES = {'content.opf', 'toc.ncx'}
+
+    def __init__(self, ordered_page_ids, toc_nodes, manifest_items,
+                 paragraphs, source='toc_level_1'):
+        """
+        :ordered_page_ids: list of page ids in spine order (xhtml only).
+        :toc_nodes: list of TOC root nodes (each has ``.title`` and
+            ``.href`` and ``.nodes``). May be an empty list.
+        :manifest_items: iterable of manifest items exposing ``.id`` and
+            ``.href``. Used to resolve TOC hrefs to page ids.
+        :paragraphs: list of Paragraph rows extracted from the cache.
+        :source: 'toc_level_1' | 'xhtml_file'.
+        """
+        self.ordered_page_ids = list(ordered_page_ids)
+        self.toc_nodes = list(toc_nodes or [])
+        self.manifest_items = list(manifest_items or [])
+        self.paragraphs = list(paragraphs)
+        self.source = source
+        self.aux_paragraphs = [
+            p for p in self.paragraphs if p.page in self.AUX_PAGES]
+
+    # -- boundary discovery ------------------------------------------------
+
+    def _boundaries_from_toc(self):
+        """Return an ordered list of (page_id, title) marking chapter starts.
+
+        Only top-level TOC nodes are considered. Nodes whose href cannot be
+        resolved to a manifest item are silently skipped.
+        """
+        result = []
+        seen = set()
+        for node in self.toc_nodes:
+            href = getattr(node, 'href', None)
+            title = getattr(node, 'title', None) or ''
+            page_id = _href_to_page_id(href, self.manifest_items)
+            if page_id is None or page_id in seen:
+                continue
+            if page_id not in self.ordered_page_ids:
+                continue
+            seen.add(page_id)
+            result.append((page_id, title.strip()))
+        # Sort boundaries by spine order.
+        order = {pid: i for i, pid in enumerate(self.ordered_page_ids)}
+        result.sort(key=lambda t: order[t[0]])
+        return result
+
+    def _boundaries_from_files(self):
+        """One xhtml file == one chapter. Titles are best-effort:
+
+        we use the first paragraph text from the page (truncated) if a page
+        has content, else 'Chapter N'.
+        """
+        result = []
+        by_page = {}
+        for p in self.paragraphs:
+            if p.page in self.AUX_PAGES:
+                continue
+            by_page.setdefault(p.page, []).append(p)
+        for i, pid in enumerate(self.ordered_page_ids, start=1):
+            title = _('Chapter {}').format(i)
+            content_ps = [p for p in by_page.get(pid, []) if not p.ignored]
+            if content_ps:
+                first = (content_ps[0].original or '').strip()
+                if first:
+                    title = first[:80]
+            result.append((pid, title))
+        return result
+
+    def _resolve_boundaries(self):
+        boundaries = []
+        if self.source == 'toc_level_1':
+            boundaries = self._boundaries_from_toc()
+            if len(boundaries) < 2:
+                # Not enough TOC info -> fallback.
+                boundaries = self._boundaries_from_files()
+        else:
+            boundaries = self._boundaries_from_files()
+        if not boundaries and self.ordered_page_ids:
+            # Extreme fallback: single chapter with everything.
+            boundaries = [(self.ordered_page_ids[0], _('Chapter 1'))]
+        return boundaries
+
+    # -- assembly ----------------------------------------------------------
+
+    def build(self):
+        boundaries = self._resolve_boundaries()
+        if not boundaries:
+            return []
+
+        # Determine the (start_page_id -> [page_ids...]) mapping.
+        order = {pid: i for i, pid in enumerate(self.ordered_page_ids)}
+        boundary_positions = [(order[bid], bid, title)
+                              for bid, title in boundaries]
+        boundary_positions.sort(key=lambda t: t[0])
+
+        # Build page_id -> chapter_index (1-based) mapping.
+        page_to_chapter = {}
+        chapter_page_ids = {i: [] for i in range(1, len(boundary_positions) + 1)}
+        chapter_titles = {}
+        for chap_i, (_pos, bid, title) in enumerate(
+                boundary_positions, start=1):
+            chapter_titles[chap_i] = (
+                title or _('Chapter {}').format(chap_i))
+
+        for idx, pid in enumerate(self.ordered_page_ids):
+            # Find which chapter this page belongs to: the greatest chapter
+            # start whose position <= idx.
+            chap_i = 0
+            for c_i, (pos, _bid, _t) in enumerate(
+                    boundary_positions, start=1):
+                if pos <= idx:
+                    chap_i = c_i
+                else:
+                    break
+            # If a page precedes the first boundary, attach it to chapter 1.
+            if chap_i == 0:
+                chap_i = 1
+            page_to_chapter[pid] = chap_i
+            chapter_page_ids[chap_i].append(pid)
+
+        # Group paragraphs by chapter.
+        chapter_paragraphs = {i: [] for i in chapter_titles}
+        for p in self.paragraphs:
+            if p.page in self.AUX_PAGES:
+                continue
+            chap_i = page_to_chapter.get(p.page)
+            if chap_i is None:
+                continue
+            chapter_paragraphs[chap_i].append(p)
+
+        chapters = []
+        for i in sorted(chapter_titles):
+            ch = Chapter(
+                index=i,
+                title=chapter_titles[i],
+                page_ids=chapter_page_ids[i],
+                paragraphs=chapter_paragraphs[i],
+            )
+            chapters.append(ch)
+        return chapters
+
+
+# ---------------------------------------------------------------------------
+# Token budget / chunking
+# ---------------------------------------------------------------------------
+
+
+_CJK_RE = re.compile(
+    r'[\u3000-\u303f\u3040-\u309f\u30a0-\u30ff\u3400-\u4dbf'
+    r'\u4e00-\u9fff\uac00-\ud7af\uf900-\ufaff]')
+
+
+class TokenBudget:
+    """Cheap token estimation and chunking, char-based.
+
+    We deliberately avoid heavy dependencies (tiktoken and friends): they are
+    accurate for GPT/Claude but wrong for Gemma/Mistral/others and would add
+    a >1MB payload for marginal gain. We use a simple heuristic:
+
+      * Latin/Cyrillic/etc: ~4 chars per token.
+      * CJK: ~2 chars per token (each ideograph is often one token).
+
+    For chunking we treat the paragraph as an atomic unit: a chunk contains
+    a contiguous slice of paragraphs whose combined estimated tokens fit
+    within the available budget. Paragraphs that alone exceed the budget are
+    still emitted as a single-paragraph chunk (with a warning) rather than
+    being split mid-sentence.
+    """
+
+    def __init__(self, budget=8000, ratio_latin=4.0, ratio_cjk=2.0,
+                 cjk_threshold=0.30):
+        if budget < 100:
+            budget = 100
+        self.budget = int(budget)
+        self.ratio_latin = float(ratio_latin)
+        self.ratio_cjk = float(ratio_cjk)
+        self.cjk_threshold = float(cjk_threshold)
+
+    def estimate(self, text):
+        if not text:
+            return 0
+        total = len(text)
+        cjk = len(_CJK_RE.findall(text))
+        # If more than threshold of the text is CJK, use CJK ratio for the
+        # whole string (which slightly overestimates -- desirable, we want
+        # a safety margin).
+        if total > 0 and (cjk / total) >= self.cjk_threshold:
+            return max(1, int(total / self.ratio_cjk))
+        # Mixed: apply CJK ratio to CJK chars and Latin ratio to the rest.
+        latin = total - cjk
+        return max(1, int(cjk / self.ratio_cjk + latin / self.ratio_latin))
+
+    def chunk(self, paragraphs, reserved=0):
+        """Split ``paragraphs`` into contiguous chunks fitting the budget.
+
+        :reserved: number of tokens to leave available for the system prompt,
+            the running summary, the glossary and the model reply. The
+            effective per-chunk budget is ``self.budget - reserved`` with a
+            minimum of 200 tokens.
+        """
+        available = max(200, self.budget - int(reserved))
+        chunks = []
+        current = []
+        current_tokens = 0
+        for p in paragraphs:
+            if getattr(p, 'ignored', False):
+                # Ignored paragraphs still travel through the pipeline (they
+                # must be re-injected into the DOM) but they consume no
+                # tokens for translation.
+                current.append(p)
+                continue
+            text = p.original or ''
+            tokens = self.estimate(text)
+            if tokens >= available and not current:
+                # Oversized paragraph on its own. Emit it as a single chunk
+                # (LLM might still handle it, or the caller will log a
+                # warning); do not split mid-paragraph.
+                log.warn(
+                    'Novel mode: paragraph estimated at %d tokens exceeds '
+                    'per-chunk budget %d; sending as-is.'
+                    % (tokens, available))
+                chunks.append([p])
+                current = []
+                current_tokens = 0
+                continue
+            if current_tokens + tokens > available and current:
+                chunks.append(current)
+                current = [p]
+                current_tokens = tokens
+                continue
+            current.append(p)
+            current_tokens += tokens
+        if current:
+            chunks.append(current)
+        return chunks
+
+
+# ---------------------------------------------------------------------------
+# Context / summary / glossary manager
+# ---------------------------------------------------------------------------
+
+
+# Cache info keys (single source of truth).
+INFO_NOVEL_MODE = 'novel_mode'
+INFO_NOVEL_SUMMARIES = 'novel_summaries'
+INFO_NOVEL_GLOSSARY = 'novel_glossary'
+INFO_NOVEL_PROGRESS = 'novel_progress'
+INFO_NOVEL_CHAPTERS = 'novel_chapters_meta'
+
+
+class ContextManager:
+    """Persist and expose the running context for a novel translation.
+
+    Two pieces of context are maintained:
+
+      * ``summaries``: an ordered list of dicts
+        ``{"chapter": int, "title": str, "summary": str}``, one per chapter
+        that has already been translated.
+      * ``glossary``: a dict mapping the original name (source language) to
+        a dict ``{"translation": str, "type": str, "notes": str}``. The type
+        is a free-form label (character/place/object/other/...); the notes
+        are optional.
+
+    Both are serialized as JSON in the SQLite ``info`` key/value table of the
+    translation cache. No schema change is required.
+    """
+
+    def __init__(self, cache, glossary_max_entries=200,
+                 summaries_keep_last=None):
+        """
+        :cache: a ``TranslationCache`` instance.
+        :glossary_max_entries: hard cap. When new entries would exceed it,
+            oldest entries are dropped (FIFO). Set to 0 for no limit.
+        :summaries_keep_last: if not None, only the last N summaries are
+            included in ``context_text``. Older ones still remain persisted
+            in case the user wants to see them in the UI.
+        """
+        self.cache = cache
+        self.glossary_max_entries = int(glossary_max_entries or 0)
+        self.summaries_keep_last = summaries_keep_last
+        self.summaries = []
+        self.glossary = {}
+        self.progress = 0
+
+    # -- persistence -------------------------------------------------------
+
+    def load(self):
+        raw = self.cache.get_info(INFO_NOVEL_SUMMARIES)
+        try:
+            self.summaries = json.loads(raw) if raw else []
+            if not isinstance(self.summaries, list):
+                self.summaries = []
+        except (ValueError, TypeError):
+            self.summaries = []
+
+        raw = self.cache.get_info(INFO_NOVEL_GLOSSARY)
+        try:
+            self.glossary = json.loads(raw) if raw else {}
+            if not isinstance(self.glossary, dict):
+                self.glossary = {}
+        except (ValueError, TypeError):
+            self.glossary = {}
+
+        raw = self.cache.get_info(INFO_NOVEL_PROGRESS)
+        try:
+            self.progress = int(raw) if raw else 0
+        except (ValueError, TypeError):
+            self.progress = 0
+
+        self.cache.set_info(INFO_NOVEL_MODE, '1')
+        return self
+
+    def _persist(self):
+        self.cache.set_info(
+            INFO_NOVEL_SUMMARIES, json.dumps(
+                self.summaries, ensure_ascii=False))
+        self.cache.set_info(
+            INFO_NOVEL_GLOSSARY, json.dumps(
+                self.glossary, ensure_ascii=False))
+        self.cache.set_info(INFO_NOVEL_PROGRESS, str(self.progress))
+
+    # -- getters -----------------------------------------------------------
+
+    def get_progress(self):
+        return self.progress
+
+    def get_summaries(self):
+        return list(self.summaries)
+
+    def get_glossary(self):
+        return dict(self.glossary)
+
+    # -- mutation ----------------------------------------------------------
+
+    def append_chapter(self, chapter_index, title, summary,
+                       glossary_updates=None):
+        """Record that ``chapter_index`` was completed.
+
+        :summary: the summary text (already in the target language).
+        :glossary_updates: iterable of dicts with at least ``source`` and
+            ``translation`` keys; ``type`` and ``notes`` are optional.
+            Duplicates (by ``source``) update the existing entry.
+        """
+        summary = (summary or '').strip()
+        if summary or title:
+            self.summaries.append({
+                'chapter': int(chapter_index),
+                'title': title or '',
+                'summary': summary,
+            })
+        if glossary_updates:
+            self._merge_glossary(glossary_updates)
+        # Progress advances only forward.
+        if chapter_index > self.progress:
+            self.progress = int(chapter_index)
+        self._persist()
+
+    def _merge_glossary(self, updates):
+        for item in updates:
+            if not isinstance(item, dict):
+                continue
+            source = (item.get('source') or '').strip()
+            translation = (item.get('translation') or '').strip()
+            if not source or not translation:
+                continue
+            entry = self.glossary.get(source, {})
+            entry['translation'] = translation
+            if item.get('type'):
+                entry['type'] = str(item['type']).strip()
+            if item.get('notes'):
+                entry['notes'] = str(item['notes']).strip()
+            self.glossary[source] = entry
+        # Enforce cap (FIFO on insertion order preserved by dict).
+        if self.glossary_max_entries and \
+                len(self.glossary) > self.glossary_max_entries:
+            overflow = len(self.glossary) - self.glossary_max_entries
+            for key in list(self.glossary.keys())[:overflow]:
+                del self.glossary[key]
+
+    def replace_glossary(self, new_glossary):
+        """Wholesale replacement (used by the UI editor)."""
+        self.glossary = {
+            k: v for k, v in new_glossary.items()
+            if isinstance(v, dict) and v.get('translation')}
+        self._persist()
+
+    def reset(self):
+        self.summaries = []
+        self.glossary = {}
+        self.progress = 0
+        self._persist()
+
+    # -- context composition ----------------------------------------------
+
+    def _format_summaries(self, summaries):
+        if not summaries:
+            return _('(none)')
+        lines = []
+        for s in summaries:
+            title = s.get('title') or ''
+            head = _('Chapter {n}').format(n=s.get('chapter', '?'))
+            if title:
+                head = '%s - %s' % (head, title)
+            body = (s.get('summary') or '').strip()
+            if body:
+                lines.append('- %s: %s' % (head, body))
+            else:
+                lines.append('- %s' % head)
+        return '\n'.join(lines)
+
+    def _format_glossary(self, glossary):
+        if not glossary:
+            return _('(empty)')
+        lines = []
+        for source, entry in glossary.items():
+            translation = entry.get('translation', '')
+            gtype = entry.get('type', '')
+            notes = entry.get('notes', '')
+            extras = []
+            if gtype:
+                extras.append(gtype)
+            if notes:
+                extras.append(notes)
+            suffix = ' (%s)' % ', '.join(extras) if extras else ''
+            lines.append('- %s -> %s%s' % (source, translation, suffix))
+        return '\n'.join(lines)
+
+    def context_text(self, budget_tokens=1500, ratio=4.0):
+        """Return a formatted string containing the recent summaries and the
+        full glossary, truncated to fit ``budget_tokens`` (approximate).
+
+        Priority when trimming (from most to least important, i.e. dropped
+        last): glossary > most recent summaries > older summaries.
+        """
+        max_chars = max(200, int(budget_tokens * ratio))
+
+        summaries = self.summaries
+        if self.summaries_keep_last is not None:
+            summaries = summaries[-int(self.summaries_keep_last):]
+
+        glossary_text = self._format_glossary(self.glossary)
+        summaries_text = self._format_summaries(summaries)
+
+        combined = (
+            _('Story so far (previous chapters summary):') + '\n'
+            + summaries_text + '\n\n'
+            + _('Glossary (use these exact translations):') + '\n'
+            + glossary_text)
+
+        if len(combined) <= max_chars:
+            return combined
+
+        # Progressively drop oldest summaries.
+        while len(summaries) > 1:
+            summaries = summaries[1:]
+            summaries_text = self._format_summaries(summaries)
+            combined = (
+                _('Story so far (previous chapters summary):') + '\n'
+                + summaries_text + '\n\n'
+                + _('Glossary (use these exact translations):') + '\n'
+                + glossary_text)
+            if len(combined) <= max_chars:
+                return combined
+
+        # Still too big: truncate glossary lines.
+        glossary_lines = glossary_text.split('\n')
+        while glossary_lines and len(combined) > max_chars:
+            glossary_lines.pop()
+            glossary_text = '\n'.join(glossary_lines) or _('(truncated)')
+            combined = (
+                _('Story so far (previous chapters summary):') + '\n'
+                + summaries_text + '\n\n'
+                + _('Glossary (use these exact translations):') + '\n'
+                + glossary_text)
+        return combined
+
+
+# ---------------------------------------------------------------------------
+# Prompt templates
+# ---------------------------------------------------------------------------
+
+
+DEFAULT_NOVEL_TRANSLATION_PROMPT = (
+    'You are a professional literary translator working on a novel. '
+    'Translate the given content from <slang> to <tlang>. Preserve the '
+    'author\'s narrative voice, tone, register and pacing. Do NOT summarize, '
+    'shorten, expand, or explain anything. Do NOT answer questions in the '
+    'text. Respond only with the translation itself.\n\n'
+    '{context}\n\n'
+    'FORMAT RULES (MUST be followed strictly):\n'
+    '- The source content is split into paragraphs, each wrapped between '
+    'markers <P1>...</P1>, <P2>...</P2>, and so on.\n'
+    '- Return the translation using the exact same markers with the exact '
+    'same numbers, in the same order. Do NOT rename, drop, add, split or '
+    'merge paragraphs.\n'
+    '- Do NOT translate the markers themselves.\n'
+    '- Preserve verbatim any inline placeholder that matches the pattern '
+    '{{id_XXXXX}} (they represent images, line breaks or other elements).\n'
+    '- Do not add any prefix, suffix, explanation or commentary outside '
+    'the markers.')
+
+
+DEFAULT_NOVEL_SUMMARY_PROMPT = (
+    'Summarize the following chapter of a novel in <tlang>. '
+    'Write 150 to 350 words. Focus on: plot events, character '
+    'introductions and developments, key locations, and any information '
+    'that will be useful to translate the following chapters consistently '
+    '(e.g. relationships between characters, unresolved threads). '
+    'Do not include any preamble or metacommentary; return the summary '
+    'text only.\n\n'
+    'Chapter {chapter_num}: "{chapter_title}"\n\n'
+    '{text}')
+
+
+DEFAULT_NOVEL_GLOSSARY_PROMPT = (
+    'You extract named entities from a translated novel chapter. '
+    'List NEW entities not already in the existing list: characters, '
+    'places, unique objects, organizations.\n\n'
+    'Reply with ONLY a JSON object. No preamble, no explanation, no '
+    'markdown fences. Follow this exact schema:\n\n'
+    '{{"entities": [\n'
+    '  {{"source": "Aslan", "translation": "Aslan", "type": "character", '
+    '"notes": "the lion"}},\n'
+    '  {{"source": "Narnia", "translation": "Narnia", "type": "place", '
+    '"notes": ""}}\n'
+    ']}}\n\n'
+    'If no new entities, reply exactly: {{"entities": []}}\n\n'
+    'Existing (skip these): {existing_keys}\n\n'
+    'Source:\n{source_text}\n\n'
+    'Translation:\n{translated_text}')
+
+
+# ---------------------------------------------------------------------------
+# Paragraph tagging / alignment
+# ---------------------------------------------------------------------------
+
+
+_TAG_RE = re.compile(r'<P(\d+)>(.*?)</P\1>', re.DOTALL)
+
+
+def tag_paragraphs(paragraphs):
+    """Return the ``<Pn>...</Pn>`` block that will be sent to the LLM plus
+    the list of indices used (in order).
+
+    Ignored paragraphs are skipped (they carry no translatable content).
+    """
+    lines = []
+    indices = []
+    for i, p in enumerate(paragraphs, start=1):
+        if getattr(p, 'ignored', False):
+            continue
+        text = (p.original or '').strip()
+        # We keep the newline structure inside the paragraph as-is; the
+        # regex uses re.DOTALL so it will match across newlines.
+        lines.append('<P%d>%s</P%d>' % (i, text, i))
+        indices.append(i)
+    return '\n'.join(lines), indices
+
+
+def parse_tagged_response(response, expected_indices):
+    """Parse an LLM response containing ``<Pn>...</Pn>`` markers.
+
+    Returns a dict ``{index: translation}``. Missing indices are absent
+    from the dict; callers can then decide how to handle the mismatch.
+    """
+    if not response:
+        return {}
+    found = {}
+    for m in _TAG_RE.finditer(response):
+        try:
+            idx = int(m.group(1))
+        except (ValueError, TypeError):
+            continue
+        # Latest occurrence wins if duplicated.
+        found[idx] = m.group(2).strip()
+    # Filter to only expected indices to avoid pollution from
+    # hallucinated tags.
+    return {i: found[i] for i in expected_indices if i in found}
+
+
+# ---------------------------------------------------------------------------
+# Novel translator (sequential orchestrator)
+# ---------------------------------------------------------------------------
+
+
+def _extract_json_object(text):
+    """Best-effort extraction of the first top-level JSON object in ``text``.
+
+    LLMs (especially small ones) sometimes wrap JSON output in prose or a
+    Markdown code fence. We scan for the first ``{`` and take the balanced
+    substring up to its matching ``}``.
+    """
+    if not text:
+        return None
+    # Strip common markdown fences first (```json ... ```).
+    fence_stripped = re.sub(
+        r'^```(?:json)?\s*\n?|\n?```\s*$', '', text.strip(), flags=re.M)
+    for candidate_text in (fence_stripped, text):
+        start = candidate_text.find('{')
+        if start < 0:
+            continue
+        depth = 0
+        in_string = False
+        escape = False
+        for i in range(start, len(candidate_text)):
+            ch = candidate_text[i]
+            if in_string:
+                if escape:
+                    escape = False
+                elif ch == '\\':
+                    escape = True
+                elif ch == '"':
+                    in_string = False
+                continue
+            if ch == '"':
+                in_string = True
+                continue
+            if ch == '{':
+                depth += 1
+            elif ch == '}':
+                depth -= 1
+                if depth == 0:
+                    candidate = candidate_text[start:i + 1]
+                    try:
+                        return json.loads(candidate)
+                    except ValueError:
+                        break  # try next candidate_text
+    return None
+
+
+# Fallback pattern for line-based entity extraction when JSON parsing fails.
+# Matches lines like:
+#   "Aslan" -> "Aslan" (character): the lion
+#   Aslan -> Aslan (character) - the lion
+#   Aslan => Aslan (character)
+#   "Frodo" → "Frodo" (character): the hobbit
+# The separator between source and translation is restricted to arrow-like
+# symbols (``->``, ``=>``, ``→``) which are unambiguous entity mappings;
+# colon and pipe alone would match prose lines like "Here are the
+# entities: ...".
+_ENTITY_LINE_PATTERNS = [
+    re.compile(
+        # source: run of non-quote, non-arrow-marker chars.
+        r'["\']?(?P<source>[^"\'\n\->=→|(]{1,80}?)["\']?\s*'
+        # separator: any arrow form.
+        r'(?:->|→|=>)\s*'
+        # translation: run stopping before optional (type) or notes.
+        r'["\']?(?P<translation>[^"\'\n(]{1,120}?)["\']?\s*'
+        # optional (type)
+        r'(?:\((?P<type>[^)\n]+)\))?\s*'
+        # optional notes prefixed by : or - or |
+        r'(?:[:\-\|]\s*(?P<notes>[^\n]{1,200}))?',
+        re.MULTILINE),
+]
+
+
+def _extract_entities_fallback(text):
+    """Extract entities using line-based regex when JSON parsing fails.
+
+    Returns a list of dicts compatible with ``_extract_glossary_updates``.
+    Only returns entries that look plausible (both source and translation
+    non-empty, source shorter than 80 chars).
+    """
+    if not text:
+        return []
+    # Try to find lines that look like key/value entity mappings. We are
+    # deliberately conservative: prefer no entries over noisy ones.
+    entities = []
+    seen_sources = set()
+    for pattern in _ENTITY_LINE_PATTERNS:
+        for m in pattern.finditer(text):
+            source = (m.group('source') or '').strip(' "\',.;')
+            translation = (m.group('translation') or '').strip(' "\',.;')
+            # Filter obvious noise: skip lines that don't look like entities.
+            if not source or not translation:
+                continue
+            if source == translation and len(source) < 3:
+                continue
+            if len(source) > 80 or len(translation) > 120:
+                continue
+            # Skip lines that are clearly prose (contain verbs / long text).
+            if source.count(' ') > 5:
+                continue
+            if source.lower() in seen_sources:
+                continue
+            seen_sources.add(source.lower())
+            entities.append({
+                'source': source,
+                'translation': translation,
+                'type': (m.group('type') or '').strip() or 'other',
+                'notes': (m.group('notes') or '').strip(' "\',.;'),
+            })
+    return entities
+
+
+class NovelTranslator:
+    """Sequential chapter-by-chapter translator with running context.
+
+    Design constraints (contrasted with ``lib.translation.Translation``):
+
+      * strictly sequential: chapter N+1 depends on the summary of chapter N.
+      * per-chunk retry with alignment-aware re-request.
+      * writes each translated paragraph into the cache as soon as it is
+        available, so an interruption leaves a partial-but-consistent state.
+      * bumps ``ContextManager.progress`` only when a full chapter is done.
+
+    The translator engine is expected to expose the same interface as
+    ``engines.base.Base.translate(text)`` and, if it is a ``GenAI`` subclass,
+    the helper ``override_prompt(prompt)`` -- but we fall back gracefully
+    if the helper is not available by assigning to ``translator.prompt``
+    directly.
+    """
+
+    def __init__(self, translator, chapters, context_manager, cache,
+                 config=None):
+        self.translator = translator
+        self.chapters = list(chapters)
+        self.ctx = context_manager
+        self.cache = cache
+        self.config = dict(config or {})
+
+        # Callbacks (all optional; safe defaults).
+        self.progress = dummy       # (fraction: float, message: str)
+        self.log = dummy            # (message: str, is_error: bool=False)
+        self.chapter_started = dummy   # (chapter: Chapter)
+        self.chapter_done = dummy      # (chapter: Chapter, summary: str,
+                                       #  glossary_delta: list[dict])
+        self.cancel_request = lambda: False
+
+        # Runtime state.
+        self.abort_count = 0
+        self.total_chapters = 0
+        self.completed_chapters = 0
+
+    # -- setters (mirroring lib.translation.Translation) -------------------
+
+    def set_progress(self, cb):
+        self.progress = cb or dummy
+
+    def set_logging(self, cb):
+        self.log = cb or dummy
+
+    def set_chapter_started(self, cb):
+        self.chapter_started = cb or dummy
+
+    def set_chapter_done(self, cb):
+        self.chapter_done = cb or dummy
+
+    def set_cancel_request(self, cb):
+        self.cancel_request = cb or (lambda: False)
+
+    # -- configuration accessors ------------------------------------------
+
+    def _cfg(self, key, default):
+        return self.config.get(key, default) if self.config else default
+
+    @property
+    def chunk_tokens(self):
+        return int(self._cfg('novel_chunk_tokens', 8000))
+
+    @property
+    def context_tokens(self):
+        return int(self._cfg('novel_context_tokens', 1500))
+
+    @property
+    def summary_tokens(self):
+        return int(self._cfg('novel_summary_tokens', 400))
+
+    @property
+    def min_chars_for_context(self):
+        """Minimum translated-chapter length below which summary+glossary
+        LLM calls are skipped. Guards against wasting time on front/back
+        matter (Copyright, Table of Contents, About the Author, ...).
+        """
+        return int(self._cfg('novel_min_chars_for_context', 300))
+
+    @property
+    def translation_prompt(self):
+        value = self._cfg('novel_translation_prompt', None)
+        return value or DEFAULT_NOVEL_TRANSLATION_PROMPT
+
+    @property
+    def summary_prompt(self):
+        value = self._cfg('novel_summary_prompt', None)
+        return value or DEFAULT_NOVEL_SUMMARY_PROMPT
+
+    @property
+    def glossary_prompt(self):
+        value = self._cfg('novel_glossary_prompt', None)
+        return value or DEFAULT_NOVEL_GLOSSARY_PROMPT
+
+    # -- engine plumbing ---------------------------------------------------
+
+    def _apply_prompt(self, prompt_text):
+        """Swap the engine's system prompt for the duration of one request.
+
+        Uses ``override_prompt`` if defined by the engine (GenAI helper),
+        else falls back to assigning to ``.prompt`` directly.
+        """
+        if hasattr(self.translator, 'override_prompt'):
+            self.translator.override_prompt(prompt_text)
+        else:
+            self.translator.prompt = prompt_text
+
+    def _restore_prompt(self):
+        if hasattr(self.translator, 'restore_prompt'):
+            self.translator.restore_prompt()
+
+    def _fill_placeholders(self, template, extra=None):
+        source_lang = getattr(self.translator, 'source_lang', '') or ''
+        target_lang = getattr(self.translator, 'target_lang', '') or ''
+        replacements = {
+            '<slang>': source_lang or 'source language',
+            '<tlang>': target_lang or 'target language',
+        }
+        if extra:
+            replacements.update(extra)
+        for k, v in replacements.items():
+            template = template.replace(k, v)
+        return template
+
+    def _run_translation_call(self, user_text):
+        """Invoke ``translator.translate`` handling both plain-string and
+        generator (streaming) return values.
+        """
+        result = self.translator.translate(user_text)
+        # Streaming: collect the generator.
+        if hasattr(result, '__iter__') and not isinstance(result, str):
+            try:
+                result = ''.join(chunk for chunk in result)
+            except TypeError:
+                # Not actually a generator (e.g. bytes), let the engine
+                # deal with it.
+                pass
+        return result or ''
+
+    def _translate_with_retry(self, system_prompt, user_text, attempts=None):
+        """Send ``system_prompt`` + ``user_text`` to the LLM with retries.
+
+        Retries here are for total failures of the request (network,
+        parsing, ...). Alignment-level retries are handled separately by
+        ``_translate_chunk``.
+        """
+        attempts = attempts or getattr(
+            self.translator, 'request_attempt', 3) or 3
+        last_error = None
+        for attempt in range(1, attempts + 1):
+            if self.cancel_request():
+                raise TranslationCanceled(_('Translation canceled.'))
+            try:
+                self._apply_prompt(system_prompt)
+                return self._run_translation_call(user_text)
+            except Exception as e:
+                last_error = e
+                self.log(
+                    _('Novel mode request failed (attempt {}/{}): {}').format(
+                        attempt, attempts, e), True)
+                time.sleep(min(30, 5 * attempt))
+            finally:
+                self._restore_prompt()
+        raise TranslationFailed(
+            _('Novel mode: giving up after {} attempts. Last error: {}')
+            .format(attempts, last_error))
+
+    # -- chunk-level translation with alignment retry ---------------------
+
+    def _translate_chunk(self, chunk_paragraphs, context_text,
+                         chapter_num, chapter_title, chunk_num, total_chunks):
+        """Translate one chunk of paragraphs, returning a dict
+        ``{paragraph_index: translation}`` covering all non-ignored
+        paragraphs. If the LLM misses some indices, up to 2 alignment
+        retries are attempted before giving up (missing translations end
+        up as ``None`` and the caller may re-run with a smaller chunk).
+        """
+        tagged, indices = tag_paragraphs(chunk_paragraphs)
+        if not indices:
+            return {}
+
+        system_prompt = self._fill_placeholders(
+            self.translation_prompt, extra={'{context}': context_text})
+        header = _('Chapter {n}: "{title}" (chunk {c}/{t})').format(
+            n=chapter_num, title=chapter_title,
+            c=chunk_num, t=total_chunks)
+        user_text = '%s\n\n%s' % (header, tagged)
+
+        response = self._translate_with_retry(system_prompt, user_text)
+        parsed = parse_tagged_response(response, indices)
+        missing = [i for i in indices if i not in parsed]
+
+        # Alignment retries: only ask for the missing paragraphs so the LLM
+        # doesn't waste tokens re-translating the ones we already have.
+        for retry in range(2):
+            if not missing:
+                break
+            self.log(
+                _('Alignment retry {}: {} missing tags.').format(
+                    retry + 1, len(missing)))
+            fixup_paras = [chunk_paragraphs[i - 1] for i in missing]
+            fixup_tagged, _fixup_idx = tag_paragraphs(fixup_paras)
+            # Re-tag using the original indices so downstream logic stays
+            # consistent.
+            # (tag_paragraphs numbers from 1..len(fixup_paras); rewrite it.)
+            fixup_tagged = self._retag(fixup_paras, missing)
+            user_text = (
+                _('The previous response was incomplete. Please translate '
+                  'only the following paragraphs, keeping the exact tag '
+                  'numbers shown:') + '\n\n' + fixup_tagged)
+            response = self._translate_with_retry(system_prompt, user_text)
+            fixup_parsed = parse_tagged_response(response, missing)
+            parsed.update(fixup_parsed)
+            missing = [i for i in indices if i not in parsed]
+
+        if missing:
+            self.log(
+                _('Warning: {} paragraph(s) missing after retries: {}').format(
+                    len(missing), missing), True)
+        return parsed
+
+    def _retag(self, paragraphs, indices):
+        """Like ``tag_paragraphs`` but forces the tag numbers to be exactly
+        ``indices`` (skipping ignored paragraphs).
+        """
+        assert len(paragraphs) == len(indices)
+        lines = []
+        for p, idx in zip(paragraphs, indices):
+            if getattr(p, 'ignored', False):
+                continue
+            text = (p.original or '').strip()
+            lines.append('<P%d>%s</P%d>' % (idx, text, idx))
+        return '\n'.join(lines)
+
+    # -- summary / glossary extraction -------------------------------------
+
+    def _build_translated_chapter_text(self, paragraphs, translations):
+        parts = []
+        for i, p in enumerate(paragraphs, start=1):
+            if getattr(p, 'ignored', False):
+                continue
+            t = translations.get(i)
+            if t:
+                parts.append(t)
+        return '\n\n'.join(parts)
+
+    def _build_source_chapter_text(self, paragraphs):
+        parts = []
+        for p in paragraphs:
+            if getattr(p, 'ignored', False):
+                continue
+            text = (p.original or '').strip()
+            if text:
+                parts.append(text)
+        return '\n\n'.join(parts)
+
+    def _generate_summary(self, chapter, translated_text):
+        if not translated_text.strip():
+            return ''
+        system_prompt = self._fill_placeholders(
+            _('You are a helpful assistant that produces concise summaries.'))
+        user_prompt = self._fill_placeholders(
+            self.summary_prompt.format(
+                chapter_num=chapter.index,
+                chapter_title=chapter.title,
+                text=translated_text))
+        try:
+            response = self._translate_with_retry(
+                system_prompt, user_prompt, attempts=2)
+        except TranslationFailed as e:
+            self.log(_('Summary generation failed: {}').format(e), True)
+            return ''
+        return response.strip()
+
+    def _extract_glossary_updates(self, chapter, source_text, translated_text):
+        if not source_text.strip() or not translated_text.strip():
+            return []
+        existing_keys = ', '.join(sorted(self.ctx.get_glossary().keys())) \
+            or _('(none)')
+        system_prompt = self._fill_placeholders(
+            _('You are a helpful assistant. Answer with strict JSON only.'))
+        user_prompt = self._fill_placeholders(
+            self.glossary_prompt.format(
+                existing_keys=existing_keys,
+                source_text=source_text,
+                translated_text=translated_text))
+        try:
+            response = self._translate_with_retry(
+                system_prompt, user_prompt, attempts=2)
+        except TranslationFailed as e:
+            self.log(
+                _('Glossary extraction failed: {}').format(e), True)
+            return []
+
+        entities = []
+        # Path 1: JSON parsing (preferred).
+        obj = _extract_json_object(response)
+        if obj and isinstance(obj.get('entities'), list):
+            for item in obj['entities']:
+                if not isinstance(item, dict):
+                    continue
+                src = (item.get('source') or '').strip()
+                tgt = (item.get('translation') or '').strip()
+                if not src or not tgt:
+                    continue
+                entities.append({
+                    'source': src,
+                    'translation': tgt,
+                    'type': (item.get('type') or '').strip() or 'other',
+                    'notes': (item.get('notes') or '').strip(),
+                })
+
+        # Path 2: line-based regex fallback if JSON gave us nothing.
+        if not entities:
+            fallback = _extract_entities_fallback(response)
+            if fallback:
+                self.log(
+                    _('Glossary extraction: JSON not usable, recovered '
+                      '{} entries via fallback parser.').format(
+                          len(fallback)))
+                entities = fallback
+            else:
+                self.log(
+                    _('Glossary extraction: could not parse JSON, '
+                      'skipping.'), True)
+
+        # Filter out entities already present (LLMs often repeat despite
+        # being told not to).
+        existing = set(self.ctx.get_glossary().keys())
+        filtered = [e for e in entities if e['source'] not in existing]
+        if filtered:
+            self.log(_('Glossary: +{} new entries (chapter {}).').format(
+                len(filtered), chapter.index))
+        return filtered
+
+    # -- persistence -------------------------------------------------------
+
+    def _store_chapter(self, chapter, translations):
+        """Write chapter translations back to cache paragraphs."""
+        engine_name = getattr(self.translator, 'name', None)
+        target_lang = None
+        if hasattr(self.translator, 'get_target_lang'):
+            try:
+                target_lang = self.translator.get_target_lang()
+            except Exception:
+                target_lang = None
+        target_lang = target_lang or getattr(
+            self.translator, 'target_lang', None)
+
+        for i, paragraph in enumerate(chapter.paragraphs, start=1):
+            if paragraph.ignored:
+                continue
+            translation = translations.get(i)
+            if translation is None:
+                continue
+            paragraph.translation = translation
+            paragraph.engine_name = engine_name
+            paragraph.target_lang = target_lang
+            paragraph.is_cache = False
+            self.cache.update_paragraph(paragraph)
+
+    # -- main loop ---------------------------------------------------------
+
+    def run(self):
+        """Execute the pipeline. Returns the number of chapters translated."""
+        self.total_chapters = len(self.chapters)
+        self.completed_chapters = 0
+        if self.total_chapters == 0:
+            self.log(_('Novel mode: no chapters to translate.'))
+            return 0
+
+        start = self.ctx.get_progress()
+        if start >= self.total_chapters:
+            self.log(
+                _('Novel mode: nothing to do (progress={}, chapters={}).')
+                .format(start, self.total_chapters))
+            return 0
+
+        self.log(sep())
+        self.log(_('Novel mode: starting.'))
+        self.log(_('Total chapters: {}').format(self.total_chapters))
+        self.log(_('Resuming from chapter: {}').format(start + 1))
+        self.log(sep('┈'))
+
+        start_ts = time.time()
+        for chapter in self.chapters[start:]:
+            if self.cancel_request():
+                raise TranslationCanceled(_('Translation canceled.'))
+            self._translate_chapter(chapter)
+            self.completed_chapters += 1
+
+        elapsed = round((time.time() - start_ts) / 60, 2)
+        self.log(sep())
+        self.log(_('Novel mode: completed {} chapter(s) in {} minutes.')
+                 .format(self.completed_chapters, elapsed))
+        self.progress(1.0, _('Novel mode: completed.'))
+        return self.completed_chapters
+
+    def _translate_chapter(self, chapter):
+        self.chapter_started(chapter)
+        self.log(sep())
+        self.log(_('Chapter {}/{}: {}').format(
+            chapter.index, self.total_chapters, chapter.title))
+
+        # Fast-path: chapter has no translatable paragraphs (e.g. cover
+        # image only). Still bump progress so we don't re-process it.
+        translatable = chapter.translatable_paragraphs()
+        if not translatable:
+            self.log(_('Chapter {} has no translatable content, skipping.')
+                     .format(chapter.index))
+            self.ctx.append_chapter(chapter.index, chapter.title, '', [])
+            self.chapter_done(chapter, '', [])
+            self._report_progress()
+            return
+
+        # Chunk.
+        budget = TokenBudget(budget=self.chunk_tokens)
+        chunks = budget.chunk(
+            translatable, reserved=self.context_tokens + self.summary_tokens)
+        total_chunks = len(chunks)
+        self.log(_('Split into {} chunk(s), ~{} tokens budget per chunk.')
+                 .format(total_chunks, self.chunk_tokens))
+
+        context_text = self.ctx.context_text(
+            budget_tokens=self.context_tokens)
+
+        # Translate each chunk.
+        translations = {}
+        # We need to map each translatable paragraph's chunk-local index to
+        # its position inside the *chapter*. Simplest: enumerate the chapter
+        # paragraphs (skipping ignored) and remember, for each chunk, which
+        # chapter-index each of its paragraphs corresponds to.
+        chapter_local_index = {}
+        counter = 0
+        for i, p in enumerate(chapter.paragraphs, start=1):
+            if p.ignored:
+                continue
+            counter += 1
+            chapter_local_index[counter] = i  # translatable_seq -> chapter_seq
+
+        seq = 0
+        for c_idx, chunk in enumerate(chunks, start=1):
+            if self.cancel_request():
+                raise TranslationCanceled(_('Translation canceled.'))
+            # Local (per-chunk) indices are what the LLM sees; we later
+            # rewrite them back into chapter-level indices.
+            chunk_result = self._translate_chunk(
+                chunk, context_text, chapter.index, chapter.title,
+                c_idx, total_chunks)
+            for local_i in range(1, len(chunk) + 1):
+                p = chunk[local_i - 1]
+                if p.ignored:
+                    continue
+                seq += 1
+                translation = chunk_result.get(local_i)
+                if translation is not None:
+                    translations[chapter_local_index[seq]] = translation
+            # Persist translations as they arrive.
+            self._store_chapter(chapter, translations)
+
+        # Summary + glossary.
+        source_text = self._build_source_chapter_text(chapter.paragraphs)
+        translated_text = self._build_translated_chapter_text(
+            chapter.paragraphs, translations)
+
+        # Skip context extraction on trivially short chapters
+        # (Copyright, TOC, About the Author, ...). They are still
+        # translated normally at the paragraph level; only the two
+        # extra LLM calls (summary + glossary) are avoided.
+        translated_len = len(translated_text.strip())
+        summary = ''
+        glossary_delta = []
+        threshold = self.min_chars_for_context
+        if translated_len < threshold:
+            self.log(_(
+                'Chapter {}: {} chars translated, below threshold {}. '
+                'Skipping summary + glossary extraction.').format(
+                    chapter.index, translated_len, threshold))
+        else:
+            summary = self._generate_summary(chapter, translated_text)
+            if summary:
+                preview = summary.strip().replace('\n', ' ')
+                if len(preview) > 160:
+                    preview = preview[:157] + '...'
+                self.log(_('Summary (chapter {}): {}').format(
+                    chapter.index, preview))
+            else:
+                self.log(_(
+                    'Summary (chapter {}): empty response.').format(
+                        chapter.index), True)
+            glossary_delta = self._extract_glossary_updates(
+                chapter, source_text, translated_text)
+
+        # Persist context (marks chapter as done, bumps progress).
+        self.ctx.append_chapter(
+            chapter.index, chapter.title, summary, glossary_delta)
+        self.chapter_done(chapter, summary, glossary_delta)
+        self._report_progress()
+
+    def _report_progress(self):
+        done = self.ctx.get_progress()
+        total = self.total_chapters or 1
+        fraction = min(1.0, done / float(total))
+        self.progress(
+            fraction,
+            _('Novel mode: chapter {}/{} done.').format(done, total))
+
+
+# ---------------------------------------------------------------------------
+# Helper: cache-id namespacing for novel mode
+# ---------------------------------------------------------------------------
+
+
+def novel_cache_id(input_path, engine_name, target_lang, encoding=''):
+    """Compute a cache id specific to novel mode.
+
+    The classic cache id (see ``lib/conversion.py:convert_item``) mixes in
+    ``merge_length``. Novel mode has no merge length, so we substitute the
+    tag ``novel_v1`` to keep the two caches strictly separated. That way,
+    switching modes on the same book does not clobber the other mode's
+    stored translations.
+    """
+    return uid(
+        input_path + engine_name + target_lang + 'novel_v1'
+        + (encoding or ''))

--- a/lib/novel.py
+++ b/lib/novel.py
@@ -276,7 +276,7 @@ _CJK_RE = re.compile(
 
 
 class TokenBudget:
-    """Cheap token estimation and chunking, char-based.
+    """Cheap token estimation and dual-cap chunking, char-based.
 
     We deliberately avoid heavy dependencies (tiktoken and friends): they are
     accurate for GPT/Claude but wrong for Gemma/Mistral/others and would add
@@ -285,18 +285,36 @@ class TokenBudget:
       * Latin/Cyrillic/etc: ~4 chars per token.
       * CJK: ~2 chars per token (each ideograph is often one token).
 
-    For chunking we treat the paragraph as an atomic unit: a chunk contains
-    a contiguous slice of paragraphs whose combined estimated tokens fit
-    within the available budget. Paragraphs that alone exceed the budget are
-    still emitted as a single-paragraph chunk (with a warning) rather than
-    being split mid-sentence.
+    Chunking is driven by **two independent caps**, both enforced
+    simultaneously: whichever is reached first closes the current chunk.
+
+      * ``budget``: maximum estimated tokens per chunk. Prevents overflowing
+        the model's context window.
+      * ``max_paragraphs``: maximum non-ignored paragraphs per chunk.
+        Prevents the LLM from being overwhelmed by too many ``<Pn>...</Pn>``
+        alignment markers when paragraphs are short (dialogue, TOC lists,
+        one-line stanzas). Empirically, medium-sized local models start
+        losing tags reliably above ~60-80 tags per chunk. Set to 0 to
+        disable this cap and fall back to token-only chunking.
+
+    Paragraphs that alone exceed the per-chunk budget are still emitted as
+    a single-paragraph chunk (with a warning) rather than being split
+    mid-sentence.
     """
 
-    def __init__(self, budget=8000, ratio_latin=4.0, ratio_cjk=2.0,
-                 cjk_threshold=0.30):
+    # Reasons why a chunk was closed. Exposed via ``chunk_with_stats``.
+    REASON_TOKENS = 'tokens'
+    REASON_PARAGRAPHS = 'paragraphs'
+    REASON_OVERSIZED = 'oversized'
+    REASON_END = 'end'
+
+    def __init__(self, budget=12000, max_paragraphs=60,
+                 ratio_latin=4.0, ratio_cjk=2.0, cjk_threshold=0.30):
         if budget < 100:
             budget = 100
         self.budget = int(budget)
+        # 0 (or negative) disables the paragraph cap.
+        self.max_paragraphs = max(0, int(max_paragraphs or 0))
         self.ratio_latin = float(ratio_latin)
         self.ratio_cjk = float(ratio_cjk)
         self.cjk_threshold = float(cjk_threshold)
@@ -316,47 +334,90 @@ class TokenBudget:
         return max(1, int(cjk / self.ratio_cjk + latin / self.ratio_latin))
 
     def chunk(self, paragraphs, reserved=0):
-        """Split ``paragraphs`` into contiguous chunks fitting the budget.
+        """Split ``paragraphs`` into contiguous chunks respecting both the
+        token budget and the paragraph cap.
 
         :reserved: number of tokens to leave available for the system prompt,
             the running summary, the glossary and the model reply. The
             effective per-chunk budget is ``self.budget - reserved`` with a
             minimum of 200 tokens.
+
+        Returns a list of paragraph-lists. Use ``chunk_with_stats`` to also
+        obtain the per-chunk token estimate and the reason why each chunk
+        was closed (useful for tuning / logging).
+        """
+        return [c for c, _tok, _reason
+                in self.chunk_with_stats(paragraphs, reserved)]
+
+    def chunk_with_stats(self, paragraphs, reserved=0):
+        """Same as :meth:`chunk` but returns list of tuples
+        ``(chunk, tokens_estimate, reason)`` where ``reason`` is one of
+        ``TokenBudget.REASON_*``. The reason indicates which limit closed
+        the chunk (or ``REASON_END`` for the tail chunk).
         """
         available = max(200, self.budget - int(reserved))
         chunks = []
         current = []
         current_tokens = 0
+        current_translatable = 0  # non-ignored paragraph count
+
         for p in paragraphs:
             if getattr(p, 'ignored', False):
                 # Ignored paragraphs still travel through the pipeline (they
                 # must be re-injected into the DOM) but they consume no
-                # tokens for translation.
+                # tokens for translation and do not count toward the
+                # paragraph cap.
                 current.append(p)
                 continue
+
             text = p.original or ''
             tokens = self.estimate(text)
-            if tokens >= available and not current:
-                # Oversized paragraph on its own. Emit it as a single chunk
-                # (LLM might still handle it, or the caller will log a
-                # warning); do not split mid-paragraph.
+
+            # Oversized single paragraph: emit alone (do not split mid-
+            # sentence). If ``current`` is non-empty flush it first so
+            # ordering is preserved.
+            if tokens >= available:
+                if current:
+                    # Determine closing reason for the flushed chunk.
+                    reason = self.REASON_TOKENS
+                    if (self.max_paragraphs
+                            and current_translatable >= self.max_paragraphs):
+                        reason = self.REASON_PARAGRAPHS
+                    chunks.append((current, current_tokens, reason))
+                    current = []
+                    current_tokens = 0
+                    current_translatable = 0
                 log.warn(
                     'Novel mode: paragraph estimated at %d tokens exceeds '
                     'per-chunk budget %d; sending as-is.'
                     % (tokens, available))
-                chunks.append([p])
-                current = []
-                current_tokens = 0
+                chunks.append(([p], tokens, self.REASON_OVERSIZED))
                 continue
-            if current_tokens + tokens > available and current:
-                chunks.append(current)
+
+            would_exceed_tokens = current_tokens + tokens > available
+            would_exceed_paragraphs = (
+                self.max_paragraphs
+                and current_translatable >= self.max_paragraphs)
+
+            if (would_exceed_tokens or would_exceed_paragraphs) and current:
+                # Which cap fired first? If both, tokens takes precedence
+                # (the harder limit for the model).
+                if would_exceed_tokens:
+                    reason = self.REASON_TOKENS
+                else:
+                    reason = self.REASON_PARAGRAPHS
+                chunks.append((current, current_tokens, reason))
                 current = [p]
                 current_tokens = tokens
+                current_translatable = 1
                 continue
+
             current.append(p)
             current_tokens += tokens
+            current_translatable += 1
+
         if current:
-            chunks.append(current)
+            chunks.append((current, current_tokens, self.REASON_END))
         return chunks
 
 
@@ -881,7 +942,19 @@ class NovelTranslator:
 
     @property
     def chunk_tokens(self):
-        return int(self._cfg('novel_chunk_tokens', 8000))
+        return int(self._cfg('novel_chunk_tokens', 12000))
+
+    @property
+    def max_paragraphs_per_chunk(self):
+        """Maximum number of translatable paragraphs per chunk.
+
+        Prevents the LLM from being overwhelmed by too many ``<Pn>...</Pn>``
+        alignment markers when paragraphs are short (dialogue, TOC lists,
+        one-line stanzas). The chunk is closed as soon as either the token
+        budget or this paragraph cap is reached -- whichever comes first.
+        Set to 0 to disable the cap and use only the token budget.
+        """
+        return int(self._cfg('novel_max_paragraphs_per_chunk', 60))
 
     @property
     def context_tokens(self):
@@ -1235,13 +1308,32 @@ class NovelTranslator:
             self._report_progress()
             return
 
-        # Chunk.
-        budget = TokenBudget(budget=self.chunk_tokens)
-        chunks = budget.chunk(
+        # Chunk with dual-cap (token budget + paragraph count).
+        budget = TokenBudget(
+            budget=self.chunk_tokens,
+            max_paragraphs=self.max_paragraphs_per_chunk,
+        )
+        chunks_with_stats = budget.chunk_with_stats(
             translatable, reserved=self.context_tokens + self.summary_tokens)
+        chunks = [c for c, _tok, _reason in chunks_with_stats]
         total_chunks = len(chunks)
-        self.log(_('Split into {} chunk(s), ~{} tokens budget per chunk.')
-                 .format(total_chunks, self.chunk_tokens))
+        cap_paragraphs_display = (
+            str(self.max_paragraphs_per_chunk)
+            if self.max_paragraphs_per_chunk else _('unlimited'))
+        self.log(_(
+            'Split into {} chunk(s). Caps: {} tokens / {} paragraphs.')
+            .format(total_chunks, self.chunk_tokens, cap_paragraphs_display))
+        # Per-chunk diagnostic (helps tune the caps against a real book).
+        # ``reason`` is one of TokenBudget.REASON_* and tells which limit
+        # closed the chunk.
+        for i, (chunk_paras, tok_est, reason) in enumerate(
+                chunks_with_stats, start=1):
+            visible = sum(
+                1 for p in chunk_paras if not getattr(p, 'ignored', False))
+            self.log(_(
+                '  Chunk {}/{}: {} paragraphs, ~{} tokens '
+                '(closed by: {}).').format(
+                    i, total_chunks, visible, tok_est, reason))
 
         context_text = self.ctx.context_text(
             budget_tokens=self.context_tokens)

--- a/lib/novel.py
+++ b/lib/novel.py
@@ -1092,7 +1092,7 @@ class NovelTranslator:
         budget or this paragraph cap is reached -- whichever comes first.
         Set to 0 to disable the cap and use only the token budget.
         """
-        return int(self._cfg('novel_max_paragraphs_per_chunk', 20))
+        return int(self._cfg('novel_max_paragraphs_per_chunk', 80))
 
     @property
     def overlap_paragraphs(self):

--- a/lib/novel.py
+++ b/lib/novel.py
@@ -126,7 +126,8 @@ class ChapterBuilder:
     AUX_PAGES = {'content.opf', 'toc.ncx'}
 
     def __init__(self, ordered_page_ids, toc_nodes, manifest_items,
-                 paragraphs, source='toc_level_1'):
+                 paragraphs, source='toc_level_1',
+                 front_matter_min_chars=100):
         """
         :ordered_page_ids: list of page ids in spine order (xhtml only).
         :toc_nodes: list of TOC root nodes (each has ``.title`` and
@@ -134,15 +135,52 @@ class ChapterBuilder:
         :manifest_items: iterable of manifest items exposing ``.id`` and
             ``.href``. Used to resolve TOC hrefs to page ids.
         :paragraphs: list of Paragraph rows extracted from the cache.
-        :source: 'toc_level_1' | 'xhtml_file'.
+        :source: 'toc_level_1' | 'toc_level_2' | 'xhtml_file'.
+        :front_matter_min_chars: XHTML pages whose total non-ignored text
+            is shorter than this threshold are considered front/back matter
+            (Cover, Titlepage, decorative pages) and their paragraphs are
+            silently dropped from chapter content. Set to 0 to disable.
         """
         self.ordered_page_ids = list(ordered_page_ids)
         self.toc_nodes = list(toc_nodes or [])
         self.manifest_items = list(manifest_items or [])
         self.paragraphs = list(paragraphs)
         self.source = source
+        self.front_matter_min_chars = max(0, int(front_matter_min_chars))
         self.aux_paragraphs = [
             p for p in self.paragraphs if p.page in self.AUX_PAGES]
+
+        # Pre-compute per-page character counts (non-ignored paragraphs only)
+        # used by the front-matter filter.
+        self._page_char_count = {}
+        for p in self.paragraphs:
+            if p.page in self.AUX_PAGES or p.ignored:
+                continue
+            self._page_char_count[p.page] = (
+                self._page_char_count.get(p.page, 0)
+                + len(p.original or ''))
+
+    def _is_front_matter(self, page_id):
+        """Return True if ``page_id`` looks like a decorative / front-matter
+        page that should be excluded from chapter content.
+
+        Detection strategy:
+
+        1. If ``front_matter_min_chars`` is 0, the filter is disabled.
+        2. Pages with fewer non-ignored characters than the threshold are
+           treated as front matter (e.g. a Titlepage that only carries
+           ``"THE MAGICIAN'S NEPHEW"`` as a single heading paragraph, or a
+           Cover page with nothing but an image).
+
+        This handles the common EPUB pattern where each book inside a
+        multi-book anthology has its own Cover.xhtml / Titlepage.xhtml that
+        contains only a large-caps styled heading.  Sending those headings
+        to the LLM as isolated paragraphs produces hallucinations because
+        the model has no narrative context around them.
+        """
+        if self.front_matter_min_chars <= 0:
+            return False
+        return self._page_char_count.get(page_id, 0) < self.front_matter_min_chars
 
     # -- boundary discovery ------------------------------------------------
 
@@ -165,6 +203,45 @@ class ChapterBuilder:
             seen.add(page_id)
             result.append((page_id, title.strip()))
         # Sort boundaries by spine order.
+        order = {pid: i for i, pid in enumerate(self.ordered_page_ids)}
+        result.sort(key=lambda t: order[t[0]])
+        return result
+
+    def _boundaries_from_toc_level2(self):
+        """Return boundaries from the *second* level of the TOC hierarchy.
+
+        Many multi-book anthologies have a two-level TOC:
+
+          Level 1: Cover.xhtml   (entire book)
+            Level 2: Chapter One  -> Chapter_1.xhtml
+            Level 2: Chapter Two  -> Chapter_2.xhtml
+            ...
+
+        Using level-2 nodes as chapter boundaries maps each narrative chapter
+        to its own translation unit, giving the LLM the chapter title in the
+        prompt header and preventing front-matter pages (Cover, Titlepage,
+        Contents) from polluting the first chunk.
+
+        If the TOC has no level-2 children or fewer than 2 usable entries,
+        falls back to level-1 boundaries.
+        """
+        result = []
+        seen = set()
+        for top_node in self.toc_nodes:
+            children = getattr(top_node, 'nodes', []) or []
+            for child in children:
+                href = getattr(child, 'href', None)
+                title = getattr(child, 'title', None) or ''
+                page_id = _href_to_page_id(href, self.manifest_items)
+                if page_id is None or page_id in seen:
+                    continue
+                if page_id not in self.ordered_page_ids:
+                    continue
+                seen.add(page_id)
+                result.append((page_id, title.strip()))
+        if len(result) < 2:
+            # Not enough level-2 entries -- fall back to level-1.
+            return self._boundaries_from_toc()
         order = {pid: i for i, pid in enumerate(self.ordered_page_ids)}
         result.sort(key=lambda t: order[t[0]])
         return result
@@ -196,7 +273,10 @@ class ChapterBuilder:
         if self.source == 'toc_level_1':
             boundaries = self._boundaries_from_toc()
             if len(boundaries) < 2:
-                # Not enough TOC info -> fallback.
+                boundaries = self._boundaries_from_files()
+        elif self.source == 'toc_level_2':
+            boundaries = self._boundaries_from_toc_level2()
+            if len(boundaries) < 2:
                 boundaries = self._boundaries_from_files()
         else:
             boundaries = self._boundaries_from_files()
@@ -243,13 +323,22 @@ class ChapterBuilder:
             page_to_chapter[pid] = chap_i
             chapter_page_ids[chap_i].append(pid)
 
-        # Group paragraphs by chapter.
+        # Group paragraphs by chapter, applying the front-matter filter.
+        # Pages identified as front matter (very short text, e.g. Cover,
+        # Titlepage) are silently excluded from chapter content.  Their
+        # paragraphs are still in the cache and will be translated by the
+        # auxiliary pipeline (metadata/TOC titles), but they will not be
+        # sent to the LLM as part of the chapter narrative payload.
         chapter_paragraphs = {i: [] for i in chapter_titles}
+        skipped_pages = set()
         for p in self.paragraphs:
             if p.page in self.AUX_PAGES:
                 continue
             chap_i = page_to_chapter.get(p.page)
             if chap_i is None:
+                continue
+            if self._is_front_matter(p.page):
+                skipped_pages.add(p.page)
                 continue
             chapter_paragraphs[chap_i].append(p)
 
@@ -308,7 +397,7 @@ class TokenBudget:
     REASON_OVERSIZED = 'oversized'
     REASON_END = 'end'
 
-    def __init__(self, budget=12000, max_paragraphs=60,
+    def __init__(self, budget=12000, max_paragraphs=80,
                  ratio_latin=4.0, ratio_cjk=2.0, cjk_threshold=0.30):
         if budget < 100:
             budget = 100
@@ -668,22 +757,27 @@ class ContextManager:
 
 DEFAULT_NOVEL_TRANSLATION_PROMPT = (
     'You are a professional literary translator working on a novel. '
-    'Translate the given content from <slang> to <tlang>. Preserve the '
-    'author\'s narrative voice, tone, register and pacing. Do NOT summarize, '
-    'shorten, expand, or explain anything. Do NOT answer questions in the '
-    'text. Respond only with the translation itself.\n\n'
-    '{context}\n\n'
-    'FORMAT RULES (MUST be followed strictly):\n'
-    '- The source content is split into paragraphs, each wrapped between '
-    'markers <P1>...</P1>, <P2>...</P2>, and so on.\n'
-    '- Return the translation using the exact same markers with the exact '
-    'same numbers, in the same order. Do NOT rename, drop, add, split or '
-    'merge paragraphs.\n'
-    '- Do NOT translate the markers themselves.\n'
-    '- Preserve verbatim any inline placeholder that matches the pattern '
-    '{{id_XXXXX}} (they represent images, line breaks or other elements).\n'
-    '- Do not add any prefix, suffix, explanation or commentary outside '
-    'the markers.')
+    'Translate from <slang> to <tlang>. Preserve the author\'s narrative '
+    'voice, tone, register and pacing. Do NOT summarize, shorten, expand, '
+    'or explain anything. Do NOT answer questions in the text.\n\n'
+    '{context}')
+
+
+# Format instructions live in the USER message, not in the system prompt.
+# Local models (Gemma, Mistral, LLaMA) tend to "forget" formatting rules
+# placed in a long system prompt but respect them when they are the last
+# thing they read before the actual task.
+DEFAULT_NOVEL_FORMAT_INSTRUCTIONS = (
+    'Translate each numbered paragraph below. Rules:\n'
+    '1) Keep the exact marker "[N]" on its own line before each translated '
+    'paragraph, in the same order and with the same numbers as the source.\n'
+    '2) Do NOT drop, add, split, merge or renumber paragraphs.\n'
+    '3) Do NOT translate the markers themselves.\n'
+    '4) Preserve verbatim any inline placeholder like {id_XXXXX} '
+    '(they represent images, line breaks and similar).\n'
+    '5) Reply with the numbered paragraphs only. No preamble, no '
+    'explanation, no closing remarks.\n\n'
+    'Source paragraphs:\n\n{text}')
 
 
 DEFAULT_NOVEL_SUMMARY_PROMPT = (
@@ -721,44 +815,90 @@ DEFAULT_NOVEL_GLOSSARY_PROMPT = (
 # ---------------------------------------------------------------------------
 
 
-_TAG_RE = re.compile(r'<P(\d+)>(.*?)</P\1>', re.DOTALL)
+# Paragraph markers
+# -----------------
+#
+# We use bracketed numeric markers ``[N]`` on their own line before each
+# paragraph rather than XML-style ``<Pn>...</Pn>`` tags. Empirically, local
+# LLMs (Gemma, Mistral, LLaMA-based) follow this format much more reliably:
+# XML tags require nested balancing which the models tend to skip when the
+# context is long, while numeric markers are the natural way these models
+# already structure numbered lists in their training data.
+#
+# Format sent to the LLM:
+#     [1]
+#     First paragraph text.
+#
+#     [2]
+#     Second paragraph text.
+#
+# Expected response:
+#     [1]
+#     Primo paragrafo tradotto.
+#
+#     [2]
+#     Secondo paragrafo tradotto.
+
+# Matches a marker line ``[N]`` capturing everything up to the next marker
+# or end of string.  MULTILINE + DOTALL so ``.`` spans newlines inside a
+# paragraph, and ``^\s*\[N\]`` anchors on a line by itself.
+_MARKER_RE = re.compile(
+    r'^[ \t]*\[(\d+)\][ \t]*\n(.*?)(?=\n[ \t]*\[\d+\][ \t]*\n|\Z)',
+    re.MULTILINE | re.DOTALL)
 
 
 def tag_paragraphs(paragraphs):
-    """Return the ``<Pn>...</Pn>`` block that will be sent to the LLM plus
+    """Return the ``[N]\\ntext`` block that will be sent to the LLM plus
     the list of indices used (in order).
 
     Ignored paragraphs are skipped (they carry no translatable content).
     """
-    lines = []
+    parts = []
     indices = []
     for i, p in enumerate(paragraphs, start=1):
         if getattr(p, 'ignored', False):
             continue
         text = (p.original or '').strip()
-        # We keep the newline structure inside the paragraph as-is; the
-        # regex uses re.DOTALL so it will match across newlines.
-        lines.append('<P%d>%s</P%d>' % (i, text, i))
+        parts.append('[%d]\n%s' % (i, text))
         indices.append(i)
-    return '\n'.join(lines), indices
+    # Blank line between paragraphs helps the LLM keep them separated and
+    # makes the parser boundary regex simpler / more robust.
+    return '\n\n'.join(parts), indices
 
 
 def parse_tagged_response(response, expected_indices):
-    """Parse an LLM response containing ``<Pn>...</Pn>`` markers.
+    """Parse an LLM response containing ``[N]`` numeric markers.
 
     Returns a dict ``{index: translation}``. Missing indices are absent
     from the dict; callers can then decide how to handle the mismatch.
+
+    The parser is tolerant of the common LLM habits:
+      * leading/trailing prose (e.g. "Here is the translation:")
+      * extra whitespace between markers
+      * duplicate markers (last one wins)
+      * hallucinated marker numbers (filtered by ``expected_indices``)
     """
     if not response:
         return {}
     found = {}
-    for m in _TAG_RE.finditer(response):
+    for m in _MARKER_RE.finditer(response):
         try:
             idx = int(m.group(1))
         except (ValueError, TypeError):
             continue
+        body = m.group(2)
+        # Trim trailing prose after the last marker: if the body ends
+        # with a blank line followed by additional text, that text is
+        # commentary (e.g. "End of translation.") and must be dropped.
+        # A blank line is ``\n\n`` with optional whitespace.
+        blank_break = re.search(r'\n[ \t]*\n', body)
+        if blank_break:
+            # Everything after the blank line is discarded UNLESS it
+            # itself contains a marker — but that case is already
+            # handled by the outer finditer, so this cut is safe.
+            body = body[:blank_break.start()]
         # Latest occurrence wins if duplicated.
-        found[idx] = m.group(2).strip()
+        found[idx] = body.strip()
     # Filter to only expected indices to avoid pollution from
     # hallucinated tags.
     return {i: found[i] for i in expected_indices if i in found}
@@ -815,11 +955,6 @@ def _extract_json_object(text):
 
 
 # Fallback pattern for line-based entity extraction when JSON parsing fails.
-# Matches lines like:
-#   "Aslan" -> "Aslan" (character): the lion
-#   Aslan -> Aslan (character) - the lion
-#   Aslan => Aslan (character)
-#   "Frodo" → "Frodo" (character): the hobbit
 # The separator between source and translation is restricted to arrow-like
 # symbols (``->``, ``=>``, ``→``) which are unambiguous entity mappings;
 # colon and pipe alone would match prose lines like "Here are the
@@ -917,6 +1052,9 @@ class NovelTranslator:
         self.abort_count = 0
         self.total_chapters = 0
         self.completed_chapters = 0
+        # One-shot log flag: set to True after the first _structured_active
+        # call logs the chosen output format. Reset per instance.
+        self._structured_choice_logged = False
 
     # -- setters (mirroring lib.translation.Translation) -------------------
 
@@ -948,13 +1086,115 @@ class NovelTranslator:
     def max_paragraphs_per_chunk(self):
         """Maximum number of translatable paragraphs per chunk.
 
-        Prevents the LLM from being overwhelmed by too many ``<Pn>...</Pn>``
+        Prevents the LLM from being overwhelmed by too many ``[N]``
         alignment markers when paragraphs are short (dialogue, TOC lists,
         one-line stanzas). The chunk is closed as soon as either the token
         budget or this paragraph cap is reached -- whichever comes first.
         Set to 0 to disable the cap and use only the token budget.
         """
-        return int(self._cfg('novel_max_paragraphs_per_chunk', 60))
+        return int(self._cfg('novel_max_paragraphs_per_chunk', 20))
+
+    @property
+    def overlap_paragraphs(self):
+        """Number of already-translated paragraphs from the previous chunk
+        to replay as narrative context for the next chunk.
+
+        Analogous to the sliding-window overlap used in RAG chunking, but
+        here the overlap serves a different purpose: it preserves
+        dialogue threads, pronoun referents and stylistic continuity
+        across chunk boundaries. The overlap is:
+
+          * shown to the LLM as *already-translated* text so it needs no
+            further translation (avoids re-cost + preserves consistency);
+          * not re-aligned into the DOM (the ``paragraph.translation``
+            for those items was already written by the previous chunk);
+          * subtracted from the per-chunk token budget so the total
+            request size stays within the model window.
+
+        Set to 0 to disable overlap entirely.
+        """
+        return max(0, int(self._cfg('novel_overlap_paragraphs', 3)))
+
+    @property
+    def structured_output_setting(self):
+        """User preference for the structured (JSON) output path.
+
+        Values:
+          ``'auto'``  -- use structured output when the current engine
+                         advertises support via ``structured_output_mode``.
+                         Otherwise fall back to text markers ``[N]``.
+                         This is the default and the safest choice.
+          ``'off'``   -- always use text markers, even if the engine
+                         supports structured output. Useful for debugging
+                         or when a specific model produces low-quality
+                         translations in JSON mode.
+          ``'force'`` -- use structured output regardless of what the
+                         engine advertises. Useful for OpenAI-compatible
+                         custom endpoints (Ollama exotics, LM Studio,
+                         vLLM, ...) that accept ``response_format`` but
+                         do not declare the capability in the plugin.
+        """
+        value = self._cfg('novel_structured_output', 'auto')
+        if value not in ('auto', 'off', 'force'):
+            value = 'auto'
+        return value
+
+    def _engine_supports_structured(self):
+        """Return True if the current translator declares native support
+        for structured output (JSON mode or JSON schema)."""
+        return getattr(
+            self.translator, 'structured_output_mode', None) in (
+                'json', 'schema')
+
+    def _structured_active(self):
+        """Combine the user setting and the engine capability to decide
+        whether the current chunk should be translated via the structured
+        path or the marker path.
+
+        Emits a one-shot log line the first time it is called so the
+        user sees which path is active without needing to inspect chunk
+        payloads. The choice is stable per translation session (the
+        engine and the config do not change mid-run).
+        """
+        setting = self.structured_output_setting
+        supports = self._engine_supports_structured()
+
+        if setting == 'off':
+            active = False
+        elif setting == 'force':
+            active = True
+        else:  # 'auto'
+            active = supports
+
+        # Verbose one-shot log: informs the user which output format the
+        # LLM will be asked to produce.
+        if not getattr(self, '_structured_choice_logged', False):
+            self._structured_choice_logged = True
+            engine_name = getattr(
+                self.translator, 'name', self.translator.__class__.__name__)
+            capability_desc = getattr(
+                self.translator, 'structured_output_mode', None) or 'none'
+            if active:
+                self.log(_(
+                    'Output format: structured JSON '
+                    '(engine={eng}, capability={cap}, setting={s}). '
+                    'Chunks can safely hold more paragraphs than with '
+                    'text markers.').format(
+                        eng=engine_name, cap=capability_desc, s=setting))
+            else:
+                if setting == 'off':
+                    reason = _('disabled by user setting')
+                elif not supports:
+                    reason = _('engine does not advertise support')
+                else:
+                    reason = _('unknown')
+                self.log(_(
+                    'Output format: text markers [N] '
+                    '(engine={eng}, capability={cap}, setting={s}, '
+                    'reason={reason}).').format(
+                        eng=engine_name, cap=capability_desc,
+                        s=setting, reason=reason))
+        return active
 
     @property
     def context_tokens(self):
@@ -1063,23 +1303,77 @@ class NovelTranslator:
     # -- chunk-level translation with alignment retry ---------------------
 
     def _translate_chunk(self, chunk_paragraphs, context_text,
-                         chapter_num, chapter_title, chunk_num, total_chunks):
+                         chapter_num, chapter_title, chunk_num, total_chunks,
+                         overlap_translations=None):
+        """Dispatcher: choose between structured (JSON) and text-marker
+        translation paths depending on engine capability and user config.
+
+        The two paths implement the same contract:
+
+            (chunk_paragraphs, ...) -> {chunk_local_index: translation}
+
+        The dispatcher swaps them transparently; the caller
+        (:meth:`_translate_chapter`) does not need to know which one was
+        used. A one-shot log line at the very first invocation records
+        the chosen path so the user can verify what is happening.
+        """
+        if self._structured_active():
+            return self._translate_chunk_structured(
+                chunk_paragraphs, context_text,
+                chapter_num, chapter_title, chunk_num, total_chunks,
+                overlap_translations=overlap_translations)
+        return self._translate_chunk_markers(
+            chunk_paragraphs, context_text,
+            chapter_num, chapter_title, chunk_num, total_chunks,
+            overlap_translations=overlap_translations)
+
+    def _translate_chunk_markers(self, chunk_paragraphs, context_text,
+                                 chapter_num, chapter_title, chunk_num,
+                                 total_chunks, overlap_translations=None):
         """Translate one chunk of paragraphs, returning a dict
         ``{paragraph_index: translation}`` covering all non-ignored
         paragraphs. If the LLM misses some indices, up to 2 alignment
         retries are attempted before giving up (missing translations end
         up as ``None`` and the caller may re-run with a smaller chunk).
+
+        :overlap_translations: optional list of already-translated
+            paragraph texts from the immediately preceding chunk. When
+            provided, they are shown to the LLM as narrative context
+            (do NOT retranslate) so it can preserve pronouns, dialogue
+            threads and stylistic continuity across chunk boundaries.
         """
         tagged, indices = tag_paragraphs(chunk_paragraphs)
         if not indices:
             return {}
 
+        # System prompt: role + languages + narrative context (summary +
+        # glossary). Static per-chapter -- no formatting rules here.
         system_prompt = self._fill_placeholders(
             self.translation_prompt, extra={'{context}': context_text})
+
+        # Build the user message. Order matters: header, then optional
+        # overlap block (already translated -- for reading only), then
+        # format instructions + the tagged source paragraphs.
         header = _('Chapter {n}: "{title}" (chunk {c}/{t})').format(
             n=chapter_num, title=chapter_title,
             c=chunk_num, t=total_chunks)
-        user_text = '%s\n\n%s' % (header, tagged)
+
+        overlap_block = ''
+        if overlap_translations:
+            joined = '\n\n'.join(
+                t.strip() for t in overlap_translations if t and t.strip())
+            if joined:
+                overlap_block = (
+                    '\n\n'
+                    + _('--- Context from previous paragraphs '
+                        '(already translated -- do NOT modify or '
+                        'retranslate this section) ---')
+                    + '\n' + joined + '\n'
+                    + _('--- End of context ---'))
+
+        format_body = self._fill_placeholders(
+            DEFAULT_NOVEL_FORMAT_INSTRUCTIONS, extra={'{text}': tagged})
+        user_text = '%s%s\n\n%s' % (header, overlap_block, format_body)
 
         response = self._translate_with_retry(system_prompt, user_text)
         parsed = parse_tagged_response(response, indices)
@@ -1087,22 +1381,27 @@ class NovelTranslator:
 
         # Alignment retries: only ask for the missing paragraphs so the LLM
         # doesn't waste tokens re-translating the ones we already have.
+        # The retry request omits the overlap block: the model has already
+        # seen the surrounding context in the initial call, and repeating
+        # it would just eat into the retry budget.
         for retry in range(2):
             if not missing:
                 break
             self.log(
-                _('Alignment retry {}: {} missing tags.').format(
+                _('Alignment retry {}: {} missing markers.').format(
                     retry + 1, len(missing)))
             fixup_paras = [chunk_paragraphs[i - 1] for i in missing]
-            fixup_tagged, _fixup_idx = tag_paragraphs(fixup_paras)
             # Re-tag using the original indices so downstream logic stays
             # consistent.
-            # (tag_paragraphs numbers from 1..len(fixup_paras); rewrite it.)
             fixup_tagged = self._retag(fixup_paras, missing)
-            user_text = (
-                _('The previous response was incomplete. Please translate '
-                  'only the following paragraphs, keeping the exact tag '
-                  'numbers shown:') + '\n\n' + fixup_tagged)
+            fixup_body = self._fill_placeholders(
+                _('The previous response was incomplete. Translate only '
+                  'the numbered paragraphs below, keeping the exact same '
+                  '[N] markers with the same numbers, in the same order. '
+                  'Reply with the numbered paragraphs only.\n\n'
+                  'Source paragraphs:\n\n{text}'),
+                extra={'{text}': fixup_tagged})
+            user_text = fixup_body
             response = self._translate_with_retry(system_prompt, user_text)
             fixup_parsed = parse_tagged_response(response, missing)
             parsed.update(fixup_parsed)
@@ -1115,17 +1414,283 @@ class NovelTranslator:
         return parsed
 
     def _retag(self, paragraphs, indices):
-        """Like ``tag_paragraphs`` but forces the tag numbers to be exactly
-        ``indices`` (skipping ignored paragraphs).
+        """Like ``tag_paragraphs`` but forces the marker numbers to be
+        exactly ``indices`` (skipping ignored paragraphs). Uses the same
+        ``[N]\\ntext`` format as :func:`tag_paragraphs`.
         """
         assert len(paragraphs) == len(indices)
-        lines = []
+        parts = []
         for p, idx in zip(paragraphs, indices):
             if getattr(p, 'ignored', False):
                 continue
             text = (p.original or '').strip()
-            lines.append('<P%d>%s</P%d>' % (idx, text, idx))
-        return '\n'.join(lines)
+            parts.append('[%d]\n%s' % (idx, text))
+        return '\n\n'.join(parts)
+
+    # -- structured (JSON) output path -------------------------------------
+
+    #: JSON Schema describing the response shape for the structured path.
+    #: Kept as a class attribute so it can be reused as a stable reference
+    #: across chunks (the value is constant per translation session).
+    _STRUCTURED_RESPONSE_SCHEMA = {
+        'type': 'object',
+        'additionalProperties': False,
+        'properties': {
+            'paragraphs': {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'additionalProperties': False,
+                    'properties': {
+                        'n': {'type': 'integer'},
+                        'translation': {'type': 'string'},
+                    },
+                    'required': ['n', 'translation'],
+                },
+            },
+        },
+        'required': ['paragraphs'],
+    }
+
+    def _build_structured_payload(self, chunk_paragraphs, indices):
+        """Return the JSON payload with source paragraphs to translate.
+
+        The response must mirror this shape but with ``translation``
+        replacing (or accompanying) the ``source`` field.
+        """
+        return {
+            'paragraphs': [
+                {
+                    'n': i,
+                    'source': (chunk_paragraphs[i - 1].original or '').strip(),
+                }
+                for i in indices
+            ],
+        }
+
+    def _parse_structured_response(self, response, expected_indices):
+        """Parse a JSON response and return ``{index: translation}``.
+
+        Robust to the common LLM sloppiness:
+          * responses wrapped in prose or Markdown fences (delegated to
+            :func:`_extract_json_object`);
+          * extra fields inside each paragraph object;
+          * ``n`` values as strings instead of integers;
+          * missing paragraphs (caller handles via alignment retry);
+          * hallucinated indices not in ``expected_indices``.
+        """
+        if not response:
+            return {}
+        obj = _extract_json_object(response)
+        if not obj or not isinstance(obj.get('paragraphs'), list):
+            return {}
+        expected = set(expected_indices)
+        result = {}
+        for item in obj['paragraphs']:
+            if not isinstance(item, dict):
+                continue
+            raw_n = item.get('n')
+            try:
+                n = int(raw_n)
+            except (TypeError, ValueError):
+                continue
+            if n not in expected:
+                continue
+            translation = (item.get('translation') or '').strip()
+            if translation:
+                result[n] = translation
+        return result
+
+    def _translate_with_retry_structured(self, system_prompt, user_text,
+                                         schema=None, attempts=None):
+        """Same retry loop as :meth:`_translate_with_retry` but the
+        request body is built via ``engine.get_body_for_structured`` so
+        the server enforces the JSON response.
+
+        The structured body includes ``stream: true`` so that long
+        responses (80+ translated paragraphs) are delivered token by
+        token without triggering the client-side request timeout.
+        Because the engine's ``_parse_stream`` returns a generator, we
+        must reassemble all chunks into a single string here before the
+        caller tries to parse the JSON.
+
+        Additionally, the engine's ``request_timeout`` is temporarily
+        raised to at least 300 seconds as a safety net: with streaming
+        the timeout only governs the connection and the first byte, so
+        300 s is never reached in practice, but it protects against edge
+        cases where the server is slow to start streaming.
+
+        TCP keepalive is also enabled for the duration of the structured
+        call (``request_keepalive = True``). This prevents intermediate
+        NAT devices / stateful firewalls (typical home routers, corporate
+        proxies) from dropping the connection during the time the LLM
+        spends generating the first token. Without keepalive we observed
+        Ollama's ``srv stop: cancel task`` at exactly the router NAT
+        session timeout (~30s).
+
+        Implementation swaps ``get_body`` temporarily rather than
+        threading a "structured" flag through :meth:`_translate_with_retry`;
+        this keeps the retry / backoff / cancel logic in one place.
+        """
+        from types import GeneratorType
+
+        translator = self.translator
+        original_get_body = translator.get_body
+        original_timeout = getattr(translator, 'request_timeout', None)
+        original_keepalive = getattr(translator, 'request_keepalive', False)
+        # Raise timeout defensively; with streaming this only covers the
+        # time until the first token arrives, not the total generation.
+        min_structured_timeout = 300.0
+        if original_timeout is not None \
+                and original_timeout < min_structured_timeout:
+            translator.request_timeout = min_structured_timeout
+        # Enable TCP keepalive on the underlying socket. The structured
+        # path may spend tens of seconds waiting for the first streamed
+        # token from the LLM; without keepalive, intermediate NAT devices
+        # (routers, corporate firewalls) silently drop the connection
+        # after ~30s of idle, causing the Ollama-side "cancel task" we
+        # observed in the logs.
+        translator.request_keepalive = True
+
+        def structured_get_body(text):
+            return translator.get_body_for_structured(text, schema)
+
+        translator.get_body = structured_get_body
+        try:
+            result = self._translate_with_retry(
+                system_prompt, user_text, attempts=attempts)
+        finally:
+            translator.get_body = original_get_body
+            if original_timeout is not None:
+                translator.request_timeout = original_timeout
+            translator.request_keepalive = original_keepalive
+
+        # If the engine returned a streaming generator (because stream:true
+        # is set in the body), collect all chunks now so the JSON parser
+        # receives the complete response string.
+        if isinstance(result, GeneratorType):
+            result = ''.join(chunk for chunk in result)
+
+        return result or ''
+
+    def _translate_chunk_structured(self, chunk_paragraphs, context_text,
+                                    chapter_num, chapter_title, chunk_num,
+                                    total_chunks, overlap_translations=None):
+        """Translate one chunk via the engine's native JSON output.
+
+        Contract identical to :meth:`_translate_chunk_markers` -- returns
+        ``{chunk_local_index: translation}`` covering all non-ignored
+        paragraphs. Alignment retries call the *marker* path as a safety
+        net so we always converge on some usable output even when the
+        JSON server rejects our schema.
+        """
+        indices = [
+            i for i, p in enumerate(chunk_paragraphs, start=1)
+            if not getattr(p, 'ignored', False)
+        ]
+        if not indices:
+            return {}
+
+        # System prompt: role + languages + narrative context (summary +
+        # glossary). Same as the marker path.
+        system_prompt = self._fill_placeholders(
+            self.translation_prompt, extra={'{context}': context_text})
+
+        # User message: header + optional overlap block + JSON schema
+        # instructions + serialized payload.
+        header = _('Chapter {n}: "{title}" (chunk {c}/{t})').format(
+            n=chapter_num, title=chapter_title,
+            c=chunk_num, t=total_chunks)
+
+        overlap_block = ''
+        if overlap_translations:
+            joined = '\n\n'.join(
+                t.strip() for t in overlap_translations if t and t.strip())
+            if joined:
+                overlap_block = (
+                    '\n\n'
+                    + _('--- Context from previous paragraphs '
+                        '(already translated -- do NOT modify or '
+                        'retranslate this section) ---')
+                    + '\n' + joined + '\n'
+                    + _('--- End of context ---'))
+
+        payload = self._build_structured_payload(chunk_paragraphs, indices)
+        payload_json = json.dumps(payload, ensure_ascii=False, indent=2)
+
+        instructions = _(
+            'You will receive a JSON object with a list of numbered '
+            'source paragraphs. Reply with a JSON object of the same '
+            'shape, where each paragraph carries a "translation" field '
+            'containing your translation of "source". Preserve the "n" '
+            'field verbatim. Preserve any inline placeholder like '
+            '{id_XXXXX}. Do not add, drop, or renumber paragraphs. '
+            'Return ONLY the JSON object, no preamble.')
+
+        user_text = (
+            '%s%s\n\n%s\n\nInput:\n%s'
+            % (header, overlap_block, instructions, payload_json))
+
+        response = self._translate_with_retry_structured(
+            system_prompt, user_text,
+            schema=self._STRUCTURED_RESPONSE_SCHEMA)
+        parsed = self._parse_structured_response(response, indices)
+        missing = [i for i in indices if i not in parsed]
+
+        # Alignment retries (structured): ask only for the missing
+        # paragraphs, still in JSON form. If two retries still fail, fall
+        # back to the marker path for the remaining ones (belt and
+        # suspenders).
+        for retry in range(2):
+            if not missing:
+                break
+            self.log(
+                _('Structured retry {}: {} missing entries.').format(
+                    retry + 1, len(missing)))
+            fixup_indices = list(missing)
+            fixup_payload = self._build_structured_payload(
+                chunk_paragraphs, fixup_indices)
+            fixup_json = json.dumps(
+                fixup_payload, ensure_ascii=False, indent=2)
+            fixup_body = (
+                _('The previous JSON response was incomplete. Reply '
+                  'with a JSON object translating ONLY the paragraphs '
+                  'below. Same shape as before: "paragraphs" array of '
+                  '{"n": int, "translation": string}. Return JSON only.')
+                + '\n\nInput:\n' + fixup_json)
+            response = self._translate_with_retry_structured(
+                system_prompt, fixup_body,
+                schema=self._STRUCTURED_RESPONSE_SCHEMA)
+            fixup_parsed = self._parse_structured_response(
+                response, fixup_indices)
+            parsed.update(fixup_parsed)
+            missing = [i for i in indices if i not in parsed]
+
+        if missing:
+            # Last-resort fallback: try the marker path for the leftover
+            # paragraphs. This handles the corner case where the server
+            # refuses the JSON schema on a specific input (rare).
+            self.log(
+                _('Structured path could not resolve {} paragraph(s); '
+                  'falling back to text markers for those.').format(
+                      len(missing)))
+            fallback_paras = [
+                chunk_paragraphs[i - 1] for i in missing]
+            fallback_result = self._translate_chunk_markers(
+                fallback_paras, context_text,
+                chapter_num, chapter_title, chunk_num, total_chunks,
+                overlap_translations=overlap_translations)
+            # Map back to the original chunk-local indices.
+            for local_i, i in enumerate(missing, start=1):
+                if local_i in fallback_result:
+                    parsed[i] = fallback_result[local_i]
+            missing = [i for i in indices if i not in parsed]
+
+        if missing:
+            self.log(
+                _('Warning: {} paragraph(s) missing after all retries: {}')
+                .format(len(missing), missing), True)
+        return parsed
 
     # -- summary / glossary extraction -------------------------------------
 
@@ -1149,16 +1714,50 @@ class NovelTranslator:
                 parts.append(text)
         return '\n\n'.join(parts)
 
+    def _head_and_tail(self, text, max_chars):
+        """Truncate ``text`` to at most ``max_chars``, keeping only the head.
+
+        Used for summary/glossary prompts. We deliberately take ONLY the
+        beginning of the translated chapter text because:
+
+          * The opening paragraphs reliably introduce the characters, setting
+            and plot thread for that chapter -- exactly what a useful summary
+            needs.
+
+        If the text already fits within ``max_chars`` it is returned verbatim.
+        If ``max_chars`` <= 0, truncation is disabled.
+        """
+        if max_chars <= 0 or len(text) <= max_chars:
+            return text
+        return text[:max_chars]
+
+    def _summary_input_budget_chars(self):
+        """Max characters to feed the summary/glossary LLM calls.
+
+        Rule of thumb: keep the input under ~4x the token budget reserved
+        for these auxiliary calls, so the model has room for its own
+        response. Hardcoded to a sensible default; the ``novel_summary_
+        input_max_chars`` config key can override.
+        """
+        default = 12000  # ~3000 words in Latin text
+        return int(self._cfg('novel_summary_input_max_chars', default))
+
     def _generate_summary(self, chapter, translated_text):
         if not translated_text.strip():
             return ''
+        max_chars = self._summary_input_budget_chars()
+        clipped = self._head_and_tail(translated_text, max_chars)
+        if len(clipped) < len(translated_text):
+            self.log(_(
+                'Summary input truncated: {} -> {} chars.').format(
+                    len(translated_text), len(clipped)))
         system_prompt = self._fill_placeholders(
             _('You are a helpful assistant that produces concise summaries.'))
         user_prompt = self._fill_placeholders(
             self.summary_prompt.format(
                 chapter_num=chapter.index,
                 chapter_title=chapter.title,
-                text=translated_text))
+                text=clipped))
         try:
             response = self._translate_with_retry(
                 system_prompt, user_prompt, attempts=2)
@@ -1170,6 +1769,9 @@ class NovelTranslator:
     def _extract_glossary_updates(self, chapter, source_text, translated_text):
         if not source_text.strip() or not translated_text.strip():
             return []
+        max_chars = self._summary_input_budget_chars()
+        src_clipped = self._head_and_tail(source_text, max_chars)
+        tgt_clipped = self._head_and_tail(translated_text, max_chars)
         existing_keys = ', '.join(sorted(self.ctx.get_glossary().keys())) \
             or _('(none)')
         system_prompt = self._fill_placeholders(
@@ -1177,8 +1779,8 @@ class NovelTranslator:
         user_prompt = self._fill_placeholders(
             self.glossary_prompt.format(
                 existing_keys=existing_keys,
-                source_text=source_text,
-                translated_text=translated_text))
+                source_text=src_clipped,
+                translated_text=tgt_clipped))
         try:
             response = self._translate_with_retry(
                 system_prompt, user_prompt, attempts=2)
@@ -1297,8 +1899,18 @@ class NovelTranslator:
         self.log(_('Chapter {}/{}: {}').format(
             chapter.index, self.total_chapters, chapter.title))
 
-        # Fast-path: chapter has no translatable paragraphs (e.g. cover
-        # image only). Still bump progress so we don't re-process it.
+        total_chars = sum(
+            len(p.original or '')
+            for p in chapter.paragraphs if not p.ignored)
+        self.log(_(
+            '  Structure: {} page(s), {} paragraphs, {} chars. '
+            'page_ids: {}').format(
+                len(chapter.page_ids),
+                len(chapter.paragraphs),
+                total_chars,
+                chapter.page_ids[:5])
+            + (' ...' if len(chapter.page_ids) > 5 else ''))
+
         translatable = chapter.translatable_paragraphs()
         if not translatable:
             self.log(_('Chapter {} has no translatable content, skipping.')
@@ -1313,16 +1925,25 @@ class NovelTranslator:
             budget=self.chunk_tokens,
             max_paragraphs=self.max_paragraphs_per_chunk,
         )
+        overlap_reserved = self.overlap_paragraphs * 80
         chunks_with_stats = budget.chunk_with_stats(
-            translatable, reserved=self.context_tokens + self.summary_tokens)
+            translatable,
+            reserved=(
+                self.context_tokens + self.summary_tokens + overlap_reserved))
         chunks = [c for c, _tok, _reason in chunks_with_stats]
         total_chunks = len(chunks)
         cap_paragraphs_display = (
             str(self.max_paragraphs_per_chunk)
             if self.max_paragraphs_per_chunk else _('unlimited'))
+        overlap_display = (
+            str(self.overlap_paragraphs)
+            if self.overlap_paragraphs else _('disabled'))
         self.log(_(
-            'Split into {} chunk(s). Caps: {} tokens / {} paragraphs.')
-            .format(total_chunks, self.chunk_tokens, cap_paragraphs_display))
+            'Split into {} chunk(s). Caps: {} tokens / {} paragraphs. '
+            'Overlap: {} paragraphs.')
+            .format(
+                total_chunks, self.chunk_tokens, cap_paragraphs_display,
+                overlap_display))
         # Per-chunk diagnostic (helps tune the caps against a real book).
         # ``reason`` is one of TokenBudget.REASON_* and tells which limit
         # closed the chunk.
@@ -1352,6 +1973,12 @@ class NovelTranslator:
             counter += 1
             chapter_local_index[counter] = i  # translatable_seq -> chapter_seq
 
+        # Sliding overlap: after each chunk we capture up to
+        # ``self.overlap_paragraphs`` of its just-produced translations
+        # and pass them to the next chunk as reading context. The first
+        # chunk of a chapter starts with an empty overlap.
+        overlap_translations = []
+
         seq = 0
         for c_idx, chunk in enumerate(chunks, start=1):
             if self.cancel_request():
@@ -1360,7 +1987,14 @@ class NovelTranslator:
             # rewrite them back into chapter-level indices.
             chunk_result = self._translate_chunk(
                 chunk, context_text, chapter.index, chapter.title,
-                c_idx, total_chunks)
+                c_idx, total_chunks,
+                overlap_translations=overlap_translations or None)
+
+            # Track the translations produced by THIS chunk so we can
+            # build the overlap for the NEXT one. We record them in the
+            # order the LLM saw them (chunk-local order), not in chapter
+            # order, so that a "recent context" window is preserved.
+            new_translations_in_chunk = []
             for local_i in range(1, len(chunk) + 1):
                 p = chunk[local_i - 1]
                 if p.ignored:
@@ -1369,8 +2003,19 @@ class NovelTranslator:
                 translation = chunk_result.get(local_i)
                 if translation is not None:
                     translations[chapter_local_index[seq]] = translation
+                    new_translations_in_chunk.append(translation)
             # Persist translations as they arrive.
             self._store_chapter(chapter, translations)
+
+            # Prepare overlap for the next chunk (last N translated
+            # paragraphs of THIS chunk). If this chunk produced fewer
+            # translations than the overlap window, the window naturally
+            # shrinks to what is available.
+            if self.overlap_paragraphs > 0 and new_translations_in_chunk:
+                overlap_translations = new_translations_in_chunk[
+                    -self.overlap_paragraphs:]
+            else:
+                overlap_translations = []
 
         # Summary + glossary.
         source_text = self._build_source_chapter_text(chapter.paragraphs)

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -153,9 +153,98 @@ def traceback_error():
     return traceback.format_exc(chain=False).strip()
 
 
+class _KeepAliveSocket(socket.socket):
+    """Socket subclass that enables TCP keepalive right after connect.
+
+    Used to prevent NAT devices / stateful firewalls from silently
+    dropping long-idle streaming HTTP connections (e.g. Ollama running
+    behind a home router while the client is remote and the model spends
+    tens of seconds generating the first token).
+
+    Values are conservative: idle=10s, interval=5s, count=3 -- a keepalive
+    probe is sent after 10s of TCP inactivity, then every 5s until either
+    the peer answers (connection stays open) or 3 probes fail (connection
+    is torn down after ~25s of unreachability).
+
+    We subclass ``socket.socket`` rather than patching an existing socket
+    because mechanize creates its sockets internally through ``socket()``
+    calls; monkey-patching the class (see ``keepalive_socket`` below)
+    lets us intercept those creations transparently.
+    """
+
+    def connect(self, address):
+        super().connect(address)
+        self._enable_keepalive()
+
+    def connect_ex(self, address):
+        result = super().connect_ex(address)
+        if result == 0:
+            self._enable_keepalive()
+        return result
+
+    def _enable_keepalive(self):
+        try:
+            self.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+            if hasattr(socket, 'TCP_KEEPIDLE'):
+                self.setsockopt(
+                    socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 10)
+            if hasattr(socket, 'TCP_KEEPINTVL'):
+                self.setsockopt(
+                    socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 5)
+            if hasattr(socket, 'TCP_KEEPCNT'):
+                self.setsockopt(
+                    socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3)
+        except (OSError, AttributeError):
+            # Some platforms (Windows in particular) expose fewer knobs.
+            # SO_KEEPALIVE alone is still helpful, so we swallow errors on
+            # the finer-grained options.
+            pass
+
+
+@contextmanager
+def keepalive_socket(enable=True) -> Generator[ModuleType, None, None]:
+    """Context manager: temporarily replace ``socket.socket`` with
+    :class:`_KeepAliveSocket` so any TCP connection opened inside the
+    ``with`` block gets TCP keepalive enabled at connect time.
+
+    When ``enable`` is False this is a pure no-op, so callers can wrap
+    unconditionally: ``with keepalive_socket(enable=needs_keepalive):``.
+    The original socket class is restored on exit even if an exception
+    is raised inside the block.
+
+    This is coordinated with :func:`socks_proxy` (which also
+    monkey-patches ``socket.socket``): the two must not be active
+    simultaneously on the same request. The novel-mode caller does not
+    use SOCKS, so there is no conflict in practice.
+    """
+    if not enable:
+        yield socket
+        return
+    previous = socket.socket
+    # Do not stack our wrapper on top of an already-patched socket (e.g.
+    # if socks_proxy is currently active). Fall back to a no-op.
+    if previous is not original_socket:
+        log.debug('keepalive_socket: socket already patched, skipping.')
+        yield socket
+        return
+    socket.socket = _KeepAliveSocket
+    try:
+        yield socket
+    finally:
+        socket.socket = previous
+
+
 def request(
         url, data=None, headers={}, method='GET', timeout=30, proxy_uri=None,
-        raw_object=False) -> Response | str | None:
+        raw_object=False, keepalive=False) -> Response | str | None:
+    """Send an HTTP request through mechanize.
+
+    :keepalive: if True, enable TCP keepalive on the underlying socket.
+        Useful for long-running streaming responses through NAT / firewalls
+        that would otherwise drop the connection when idle for 30-60s.
+        Sends a keepalive probe every 10 s of idle time and closes the
+        connection only after 3 failed probes (15 s of unreachability).
+    """
     br = Browser()
     br.set_handle_robots(False)
 
@@ -188,8 +277,14 @@ def request(
     try:
         _request = Request(
             url, data, headers=headers, timeout=timeout, method=method)
-        br.open(_request)
-        response: Response | None = br.response()
+        # Optionally wrap the socket layer with TCP keepalive so intermediate
+        # NAT devices do not silently drop long-idle streaming connections.
+        # The ``keepalive_socket`` context manager is a no-op when
+        # ``keepalive`` is False, so the fast paragraph-per-request path
+        # keeps its original behaviour.
+        with keepalive_socket(enable=keepalive):
+            br.open(_request)
+            response: Response | None = br.response()
         if response is None or raw_object:
             return response
         return response.read().decode('utf-8').strip()

--- a/novel.py
+++ b/novel.py
@@ -38,6 +38,7 @@ from .lib.translation import get_engine_class, get_translator
 from .lib.exception import TranslationCanceled, TranslationFailed
 from .lib.novel import (
     ChapterBuilder, ContextManager, NovelTranslator, novel_cache_id)
+from .lib.conversion import get_novel_config
 from .engines.genai import GenAI
 from .components import (
     Footer, AlertMessage, SourceLang, TargetLang, InputFormat, OutputFormat)
@@ -151,9 +152,13 @@ class NovelPreparationWorker(QObject):
             page_ids = [it.id for it in xhtml_items]
             source = get_config().get(
                 'novel_chapter_source', 'toc_level_1') or 'toc_level_1'
+            front_matter_min = int(
+                get_config().get('novel_front_matter_min_chars', 100) or 0)
             builder = ChapterBuilder(
                 page_ids, oeb.toc.nodes,
-                list(oeb.manifest.items), paragraphs, source=source)
+                list(oeb.manifest.items), paragraphs,
+                source=source,
+                front_matter_min_chars=front_matter_min)
             chapters = builder.build()
             for ch in chapters:
                 chapters_meta.append({
@@ -269,9 +274,12 @@ class NovelTranslationWorker(QObject):
         page_ids = [it.id for it in xhtml_items]
         source = get_config().get(
             'novel_chapter_source', 'toc_level_1') or 'toc_level_1'
+        front_matter_min = int(
+            get_config().get('novel_front_matter_min_chars', 100) or 0)
         chapters = ChapterBuilder(
             page_ids, oeb.toc.nodes, list(oeb.manifest.items),
-            paragraphs, source=source).build()
+            paragraphs, source=source,
+            front_matter_min_chars=front_matter_min).build()
 
         ctx = ContextManager(
             cache,
@@ -279,20 +287,7 @@ class NovelTranslationWorker(QObject):
                 get_config().get('novel_glossary_max_entries', 200) or 0),
         ).load()
 
-        config = get_config()
-        novel_config = {
-            'novel_chunk_tokens': config.get('novel_chunk_tokens', 8000),
-            'novel_context_tokens': config.get('novel_context_tokens', 1500),
-            'novel_summary_tokens': config.get('novel_summary_tokens', 400),
-            'novel_glossary_max_entries': config.get(
-                'novel_glossary_max_entries', 200),
-            'novel_translation_prompt': config.get(
-                'novel_translation_prompt', None),
-            'novel_summary_prompt': config.get(
-                'novel_summary_prompt', None),
-            'novel_glossary_prompt': config.get(
-                'novel_glossary_prompt', None),
-        }
+        novel_config = get_novel_config()
 
         translator_novel = NovelTranslator(
             translator, chapters, ctx, cache, config=novel_config)
@@ -663,6 +658,11 @@ class NovelTranslation(QDialog):
         btn_row.addWidget(self.close_button)
         outer.addLayout(btn_row)
 
+        # In-memory glossary accumulator. Updated incrementally from the
+        # chapter_done signal so the UI never needs to read back from SQLite
+        # (which can miss in-flight transactions from the worker thread).
+        self._ui_glossary = {}
+
         return widget
 
     # -- chapter list rendering -------------------------------------------
@@ -725,12 +725,32 @@ class NovelTranslation(QDialog):
             self.start_button.setText(_('Re-run all'))
 
     def _refresh_context_views(self, cache=None):
+        """Refresh the Summaries and Glossary tabs.
+
+        Summaries are always read from the SQLite cache (they are long
+        strings, writing them into the signal payload would be wasteful).
+
+        The glossary is read from ``self._ui_glossary``, an in-memory dict
+        that is updated incrementally by :meth:`_on_chapter_done` every
+        time the worker emits a ``chapter_done`` signal. This avoids the
+        SQLite transaction-visibility race that caused the Glossary tab to
+        appear empty during a live translation run: the worker's open
+        connection commits after each chapter, but the secondary connection
+        opened here would sometimes read stale data depending on SQLite's
+        WAL checkpoint timing.
+
+        When ``cache`` is supplied (e.g. from the initial load in
+        :meth:`_refresh_chapter_list_from_cache`), both summaries AND the
+        glossary initial state are read from it so the UI is correctly
+        restored on re-open.
+        """
         should_close = False
         if cache is None:
             cache = get_cache(self.cache_id)
             should_close = True
         try:
             import json as _json
+            # --- Summaries: always from cache ---
             raw = cache.get_info('novel_summaries')
             summaries = []
             try:
@@ -746,25 +766,35 @@ class NovelTranslation(QDialog):
                 self.summaries_view.appendPlainText(s.get('summary', ''))
                 self.summaries_view.appendPlainText('')
 
-            raw = cache.get_info('novel_glossary')
-            glossary = {}
-            try:
-                glossary = _json.loads(raw) if raw else {}
-            except (ValueError, TypeError):
-                glossary = {}
-            self.glossary_table.setRowCount(len(glossary))
-            for row, (source, entry) in enumerate(glossary.items()):
-                self.glossary_table.setItem(
-                    row, 0, QTableWidgetItem(source))
-                self.glossary_table.setItem(
-                    row, 1, QTableWidgetItem(entry.get('translation', '')))
-                self.glossary_table.setItem(
-                    row, 2, QTableWidgetItem(entry.get('type', '')))
-                self.glossary_table.setItem(
-                    row, 3, QTableWidgetItem(entry.get('notes', '')))
+            # --- Glossary: prefer in-memory accumulator; seed from cache
+            # on the initial load (when _ui_glossary is still empty).
+            if not self._ui_glossary:
+                raw = cache.get_info('novel_glossary')
+                try:
+                    self._ui_glossary = _json.loads(raw) if raw else {}
+                    if not isinstance(self._ui_glossary, dict):
+                        self._ui_glossary = {}
+                except (ValueError, TypeError):
+                    self._ui_glossary = {}
+
+            self._redraw_glossary_table()
         finally:
             if should_close:
                 cache.close()
+
+    def _redraw_glossary_table(self):
+        """Repopulate the glossary QTableWidget from ``self._ui_glossary``."""
+        glossary = self._ui_glossary
+        self.glossary_table.setRowCount(len(glossary))
+        for row, (source, entry) in enumerate(glossary.items()):
+            self.glossary_table.setItem(
+                row, 0, QTableWidgetItem(source))
+            self.glossary_table.setItem(
+                row, 1, QTableWidgetItem(entry.get('translation', '')))
+            self.glossary_table.setItem(
+                row, 2, QTableWidgetItem(entry.get('type', '')))
+            self.glossary_table.setItem(
+                row, 3, QTableWidgetItem(entry.get('notes', '')))
 
     # -- controls ----------------------------------------------------------
 
@@ -832,6 +862,23 @@ class NovelTranslation(QDialog):
 
     def _on_chapter_done(self, index, summary, glossary_delta):
         self._set_chapter_status(index, self.STATUS_DONE)
+        # Merge the glossary delta received directly from the worker signal
+        # into the in-memory accumulator. This avoids the SQLite read-back
+        # race: the delta is already the freshly extracted data, so no need
+        # to reopen the cache connection.
+        if glossary_delta:
+            for item in glossary_delta:
+                if not isinstance(item, dict):
+                    continue
+                source = (item.get('source') or '').strip()
+                translation = (item.get('translation') or '').strip()
+                if not source or not translation:
+                    continue
+                self._ui_glossary[source] = {
+                    'translation': translation,
+                    'type': (item.get('type') or '').strip(),
+                    'notes': (item.get('notes') or '').strip(),
+                }
         self._refresh_context_views()
 
     def _on_worker_finished(self, success, message):
@@ -877,6 +924,7 @@ class NovelTranslation(QDialog):
                 _json.dumps(new_glossary, ensure_ascii=False))
         finally:
             cache.close()
+        self._ui_glossary = new_glossary
         self.alert.pop(_('Glossary saved.'))
 
     def _reset_context(self):
@@ -893,6 +941,7 @@ class NovelTranslation(QDialog):
             ContextManager(cache).load().reset()
         finally:
             cache.close()
+        self._ui_glossary = {}
         for idx in list(self.status_by_chapter.keys()):
             self._set_chapter_status(idx, self.STATUS_PENDING)
         self.progress_bar.setValue(0)

--- a/novel.py
+++ b/novel.py
@@ -1,0 +1,920 @@
+"""Novel Mode UI dialog.
+
+A dedicated GUI (analogous to ``advanced.py`` and ``batch.py``) that lets
+the user run the chapter-aware sequential translation pipeline defined in
+``lib/novel.py`` on a single ebook. Unlike Advanced Mode there is no
+per-paragraph review table: the LLM operates on whole chapters, so the UI
+surfaces chapter-level progress plus tabs for the running summaries, the
+dynamic glossary and the log.
+
+Only engines that inherit from ``engines.genai.GenAI`` are eligible.
+"""
+import time
+import traceback
+from types import MethodType
+
+from qt.core import (  # type: ignore
+    Qt, QObject, QDialog, QGroupBox, QWidget, QVBoxLayout, QHBoxLayout,
+    QPlainTextEdit, QPushButton, QSplitter, QLabel, QThread, QGridLayout,
+    QProgressBar, pyqtSignal, pyqtSlot, QPixmap, QListWidget,
+    QListWidgetItem, QTabWidget, QTableWidget, QTableWidgetItem,
+    QHeaderView, QSpacerItem, QStackedWidget, QComboBox, QMessageBox,
+    QSizePolicy, QColor)
+from calibre.constants import __version__  # type: ignore
+from calibre.gui2 import I  # type: ignore
+from calibre.utils.localization import _  # type: ignore
+from calibre.ebooks.conversion.plumber import (  # type: ignore
+    Plumber, CompositeProgressReporter)
+from calibre.ptempfile import PersistentTemporaryFile  # type: ignore
+
+from . import EbookTranslator
+from .lib.utils import log, sep, uid, traceback_error
+from .lib.config import get_config
+from .lib.cache import get_cache
+from .lib.element import (
+    get_element_handler, get_page_elements, get_toc_elements,
+    get_metadata_elements)
+from .lib.translation import get_engine_class, get_translator
+from .lib.exception import TranslationCanceled, TranslationFailed
+from .lib.novel import (
+    ChapterBuilder, ContextManager, NovelTranslator, novel_cache_id)
+from .engines.genai import GenAI
+from .components import (
+    Footer, AlertMessage, SourceLang, TargetLang, InputFormat, OutputFormat)
+
+
+load_translations()  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Workers
+# ---------------------------------------------------------------------------
+
+
+class NovelPreparationWorker(QObject):
+    """Extract chapters, load context, and populate the cache.
+
+    Runs entirely off the Qt main thread. Emits ``finished(cache_id)`` when
+    ready to translate, or ``failed(str)`` on any error.
+    """
+
+    start = pyqtSignal()
+    progress_message = pyqtSignal(str)
+    progress_detail = pyqtSignal(str)
+    finished = pyqtSignal(str, object)   # cache_id, list[dict chapters meta]
+    failed = pyqtSignal(str)
+
+    def __init__(self, engine_class, ebook):
+        QObject.__init__(self)
+        self.engine_class = engine_class
+        self.ebook = ebook
+        self.canceled = False
+        self.start.connect(self.run)
+
+    def set_canceled(self, value):
+        self.canceled = value
+
+    @pyqtSlot()
+    def run(self):
+        try:
+            self._do_run()
+        except Exception as e:
+            log.error('Novel prep failed: %s' % traceback.format_exc())
+            self.failed.emit(str(e))
+
+    def _do_run(self):
+        input_path = self.ebook.get_input_path()
+        translator_name = self.engine_class.name
+        encoding = ''
+        if self.ebook.encoding.lower() != 'utf-8':
+            encoding = self.ebook.encoding.lower()
+        cache_id = novel_cache_id(
+            input_path, translator_name, self.ebook.target_lang, encoding)
+
+        cache = get_cache(cache_id)
+        cache.set_info('title', self.ebook.title)
+        cache.set_info('engine_name', translator_name)
+        cache.set_info('target_lang', self.ebook.target_lang)
+        cache.set_info('plugin_version', EbookTranslator.__version__)
+        cache.set_info('calibre_version', __version__)
+        cache.set_info('novel_mode', '1')
+
+        chapters_meta = []
+        if cache.is_fresh() or not cache.is_persistence():
+            self.progress_message.emit(_('Extracting ebook content...'))
+            # Reuse the same plumbing as advanced.extract_item, but keep the
+            # element_handler around so we can prepare_original into cache.
+            element_handler = get_element_handler(
+                self.engine_class.placeholder, self.engine_class.separator,
+                self.ebook.target_direction)
+            element_handler.set_translation_lang(
+                self.engine_class.get_iso639_target_code(
+                    self.ebook.target_lang))
+            output_path = PersistentTemporaryFile(suffix='.epub').name
+            oeb_holder = {}
+            plumber = Plumber(input_path, output_path, log=log)
+
+            def convert(pself, oeb, output_path, input_plugin, opts, plog):
+                oeb_holder['oeb'] = oeb
+                elements = []
+                elements.extend(get_metadata_elements(oeb.metadata))
+                elements.extend(get_toc_elements(oeb.toc.nodes, []))
+                elements.extend(get_page_elements(oeb.manifest.items))
+                original_group = element_handler.prepare_original(elements)
+                cache.save(original_group)
+                # Trigger the abort so plumber does not proceed to output.
+                from .lib.exception import ConversionAbort
+                raise ConversionAbort()
+
+            plumber.output_plugin.convert = MethodType(
+                convert, plumber.output_plugin)
+            try:
+                plumber.run()
+            except Exception as e:
+                from .lib.exception import ConversionAbort
+                if not isinstance(e, ConversionAbort):
+                    raise
+
+            oeb = oeb_holder.get('oeb')
+            if oeb is None:
+                raise RuntimeError(_(
+                    'Failed to load ebook: OEB not available.'))
+
+            self.progress_message.emit(_('Building chapters...'))
+            paragraphs = cache.all_paragraphs()
+            import re as _re
+            from .lib.utils import sorted_mixed_keys
+            page_pat = _re.compile(r'\.(xhtml|html|htm|xml|xht)$')
+            xhtml_items = [it for it in oeb.manifest.items
+                           if page_pat.search(it.href or '')]
+            xhtml_items.sort(key=lambda it: sorted_mixed_keys(it.href or ''))
+            page_ids = [it.id for it in xhtml_items]
+            source = get_config().get(
+                'novel_chapter_source', 'toc_level_1') or 'toc_level_1'
+            builder = ChapterBuilder(
+                page_ids, oeb.toc.nodes,
+                list(oeb.manifest.items), paragraphs, source=source)
+            chapters = builder.build()
+            for ch in chapters:
+                chapters_meta.append({
+                    'index': ch.index,
+                    'title': ch.title,
+                    'char_count': ch.char_count,
+                    'paragraphs': len(ch.paragraphs),
+                })
+            # Persist chapter metadata so subsequent openings can reuse it
+            # without re-running Plumber.
+            import json as _json
+            cache.set_info(
+                'novel_chapters_meta', _json.dumps(chapters_meta))
+        else:
+            self.progress_detail.emit(_(
+                'Loading data from cache and preparing user interface...'))
+            import json as _json
+            raw = cache.get_info('novel_chapters_meta')
+            try:
+                chapters_meta = _json.loads(raw) if raw else []
+            except (ValueError, TypeError):
+                chapters_meta = []
+
+        cache.close()
+        self.finished.emit(cache_id, chapters_meta)
+
+
+class NovelTranslationWorker(QObject):
+    """Run the sequential translation pipeline off the Qt main thread."""
+
+    start = pyqtSignal()
+    logging = pyqtSignal(str, bool)
+    progress = pyqtSignal(float, str)
+    chapter_started = pyqtSignal(int)          # chapter index
+    chapter_done = pyqtSignal(int, str, list)  # index, summary, glossary
+    finished = pyqtSignal(bool, str)           # success, message
+
+    def __init__(self, engine_class, ebook, cache_id):
+        QObject.__init__(self)
+        self.engine_class = engine_class
+        self.ebook = ebook
+        self.cache_id = cache_id
+        self.canceled = False
+        self.start.connect(self.run)
+
+    def cancel_request(self):
+        return self.canceled
+
+    def set_canceled(self, value):
+        self.canceled = value
+
+    @pyqtSlot()
+    def run(self):
+        try:
+            self._do_run()
+        except TranslationCanceled:
+            self.finished.emit(False, _('Translation canceled.'))
+        except Exception as e:
+            log.error('Novel translation failed: %s'
+                      % traceback.format_exc())
+            self.logging.emit(traceback.format_exc(), True)
+            self.finished.emit(False, str(e))
+        else:
+            self.finished.emit(True, _('Novel mode: completed.'))
+
+    def _do_run(self):
+        cache = get_cache(self.cache_id)
+        translator = get_translator(self.engine_class)
+        translator.set_source_lang(self.ebook.source_lang)
+        translator.set_target_lang(self.ebook.target_lang)
+
+        # Rebuild chapters exactly as the preparation worker did.
+        # We need to reload the OEB spine to know page_ids/titles; a
+        # cheaper alternative is to reuse the metadata we cached earlier.
+        import json as _json
+        raw = cache.get_info('novel_chapters_meta')
+        try:
+            chapters_meta = _json.loads(raw) if raw else []
+        except (ValueError, TypeError):
+            chapters_meta = []
+
+        # Fetch the paragraphs of each chapter from the cache, grouped by
+        # page. We don't have direct chapter->page mapping in the meta
+        # blob (we only stored aggregate counts) so we still need the
+        # ChapterBuilder to reconstruct chapters. Re-running plumber just
+        # for that is expensive; instead we do a light-weight OEB parse.
+        input_path = self.ebook.get_input_path()
+        plumber = Plumber(input_path, PersistentTemporaryFile(
+            suffix='.epub').name, log=log)
+        oeb_holder = {}
+
+        def convert(pself, oeb, output_path, input_plugin, opts, plog):
+            oeb_holder['oeb'] = oeb
+            from .lib.exception import ConversionAbort
+            raise ConversionAbort()
+
+        from .lib.exception import ConversionAbort
+        plumber.output_plugin.convert = MethodType(
+            convert, plumber.output_plugin)
+        try:
+            plumber.run()
+        except ConversionAbort:
+            pass
+        oeb = oeb_holder.get('oeb')
+        paragraphs = cache.all_paragraphs()
+
+        import re as _re
+        from .lib.utils import sorted_mixed_keys
+        page_pat = _re.compile(r'\.(xhtml|html|htm|xml|xht)$')
+        xhtml_items = [it for it in oeb.manifest.items
+                       if page_pat.search(it.href or '')]
+        xhtml_items.sort(key=lambda it: sorted_mixed_keys(it.href or ''))
+        page_ids = [it.id for it in xhtml_items]
+        source = get_config().get(
+            'novel_chapter_source', 'toc_level_1') or 'toc_level_1'
+        chapters = ChapterBuilder(
+            page_ids, oeb.toc.nodes, list(oeb.manifest.items),
+            paragraphs, source=source).build()
+
+        ctx = ContextManager(
+            cache,
+            glossary_max_entries=int(
+                get_config().get('novel_glossary_max_entries', 200) or 0),
+        ).load()
+
+        config = get_config()
+        novel_config = {
+            'novel_chunk_tokens': config.get('novel_chunk_tokens', 8000),
+            'novel_context_tokens': config.get('novel_context_tokens', 1500),
+            'novel_summary_tokens': config.get('novel_summary_tokens', 400),
+            'novel_glossary_max_entries': config.get(
+                'novel_glossary_max_entries', 200),
+            'novel_translation_prompt': config.get(
+                'novel_translation_prompt', None),
+            'novel_summary_prompt': config.get(
+                'novel_summary_prompt', None),
+            'novel_glossary_prompt': config.get(
+                'novel_glossary_prompt', None),
+        }
+
+        translator_novel = NovelTranslator(
+            translator, chapters, ctx, cache, config=novel_config)
+        translator_novel.set_logging(
+            lambda text, error=False: self.logging.emit(text, error))
+        translator_novel.set_progress(
+            lambda frac, msg: self.progress.emit(frac, msg))
+        translator_novel.set_cancel_request(self.cancel_request)
+        translator_novel.set_chapter_started(
+            lambda chapter: self.chapter_started.emit(chapter.index))
+        translator_novel.set_chapter_done(
+            lambda chapter, summary, delta:
+                self.chapter_done.emit(chapter.index, summary, delta or []))
+
+        translator_novel.run()
+        cache.close()
+
+
+# ---------------------------------------------------------------------------
+# CreateNovelProject: initial setup dialog (analogous to
+# advanced.CreateTranslationProject)
+# ---------------------------------------------------------------------------
+
+
+class CreateNovelProject(QDialog):
+    start_translation = pyqtSignal(object)
+
+    def __init__(self, parent, ebook):
+        QDialog.__init__(self, parent)
+        self.ebook = ebook
+        self.alert = AlertMessage(self)
+
+        layout = QVBoxLayout(self)
+        self.choose_format = self.layout_format()
+        self.start_button = QPushButton(_('&Start'))
+        self.start_button.clicked.connect(self.show_novel)
+
+        layout.addWidget(self.choose_format)
+        layout.addWidget(self.start_button)
+
+    def layout_format(self):
+        engine_class = get_engine_class()
+        widget = QWidget()
+        layout = QGridLayout(widget)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        # Warning if the engine does not support novel mode.
+        if not getattr(engine_class, 'supports_novel_mode', False):
+            warn = QLabel(_(
+                'Novel Mode requires an LLM engine (ChatGPT / Claude / '
+                'Gemini / Ollama via ChatGPT-compatible endpoint). '
+                'The current engine "{}" does not support it. '
+                'Please switch engine in Setting.').format(engine_class.name))
+            warn.setWordWrap(True)
+            warn.setStyleSheet('color:crimson;font-weight:bold;')
+            layout.addWidget(warn, 0, 0, 1, 6)
+            self.eligible = False
+        else:
+            self.eligible = True
+
+        input_group = QGroupBox(_('Input Format'))
+        input_layout = QGridLayout(input_group)
+        input_format = InputFormat(self.ebook.files.keys())
+        input_layout.addWidget(input_format)
+        layout.addWidget(input_group, 1, 0, 1, 3)
+
+        output_group = QGroupBox(_('Output Format'))
+        output_layout = QGridLayout(output_group)
+        output_format = OutputFormat()
+        output_layout.addWidget(output_format)
+        layout.addWidget(output_group, 1, 3, 1, 3)
+
+        source_group = QGroupBox(_('Source Language'))
+        source_layout = QVBoxLayout(source_group)
+        source_lang = SourceLang()
+        source_lang.setFixedWidth(150)
+        source_layout.addWidget(source_lang)
+        layout.addWidget(source_group, 2, 0, 1, 2)
+
+        target_group = QGroupBox(_('Target Language'))
+        target_layout = QVBoxLayout(target_group)
+        target_lang = TargetLang()
+        target_lang.setFixedWidth(150)
+        target_layout.addWidget(target_lang)
+        layout.addWidget(target_group, 2, 2, 1, 2)
+
+        source_lang.refresh.emit(
+            engine_class.lang_codes.get('source'),
+            engine_class.config.get('source_lang'), True)
+        target_lang.refresh.emit(
+            engine_class.lang_codes.get('target'),
+            engine_class.config.get('target_lang'))
+
+        def change_input_format(fmt):
+            self.ebook.set_input_format(fmt)
+        change_input_format(input_format.currentText())
+        input_format.currentTextChanged.connect(change_input_format)
+
+        def change_output_format(fmt):
+            self.ebook.set_output_format(fmt)
+        change_output_format(output_format.currentText())
+        output_format.currentTextChanged.connect(change_output_format)
+
+        def change_source_lang(lang):
+            self.ebook.set_source_lang(lang)
+        change_source_lang(source_lang.currentText())
+        source_lang.currentTextChanged.connect(change_source_lang)
+
+        def change_target_lang(lang):
+            self.ebook.set_target_lang(lang)
+            self.ebook.set_lang_code(
+                engine_class.get_iso639_target_code(lang))
+        change_target_lang(target_lang.currentText())
+        target_lang.currentTextChanged.connect(change_target_lang)
+
+        return widget
+
+    @pyqtSlot()
+    def show_novel(self):
+        if not self.eligible:
+            self.alert.pop(_(
+                'Please select a GenAI engine before starting novel mode.'),
+                'warning')
+            return
+        self.done(0)
+        self.start_translation.emit(self.ebook)
+
+
+# ---------------------------------------------------------------------------
+# NovelTranslation: main dialog
+# ---------------------------------------------------------------------------
+
+
+class NovelTranslation(QDialog):
+    """Main window for Novel Mode.
+
+    Layout:
+      * Left column: cover thumbnail, book title, chapter list with
+        per-chapter status icons.
+      * Right column: progress bar + tabs (Summaries / Glossary / Log).
+      * Bottom: Start / Pause / Cancel / Close buttons.
+    """
+
+    STATUS_PENDING = 0
+    STATUS_RUNNING = 1
+    STATUS_DONE = 2
+    STATUS_ERROR = 3
+
+    prep_thread = QThread()
+    trans_thread = QThread()
+
+    def __init__(self, plugin, parent, worker, ebook):
+        QDialog.__init__(self, parent)
+        self.ui_settings = plugin.ui_settings
+        self.api = parent.current_db.new_api
+        self.worker = worker
+        self.ebook = ebook
+        self.alert = AlertMessage(self)
+        self.footer = Footer()
+
+        self.config = get_config()
+        self.current_engine = get_engine_class()
+
+        self.cache_id = None
+        self.chapters_meta = []
+        self.chapter_items = {}   # index -> QListWidgetItem
+        self.status_by_chapter = {}
+        self.output_ready = False
+
+        self.prep_worker = NovelPreparationWorker(
+            self.current_engine, self.ebook)
+        self.prep_worker.moveToThread(self.prep_thread)
+        self.prep_thread.finished.connect(self.prep_worker.deleteLater)
+        self.prep_thread.start()
+
+        self.trans_worker = None  # created after preparation completes.
+
+        layout = QVBoxLayout(self)
+        self.waiting = self._layout_progress()
+        self.stack = QStackedWidget()
+        self.stack.addWidget(self.waiting)
+        layout.addWidget(self.stack)
+        layout.addWidget(self.footer)
+
+        self.prep_worker.progress_message.connect(self._prep_label.setText)
+        self.prep_worker.progress_detail.connect(
+            self._prep_detail.appendPlainText)
+        self.prep_worker.finished.connect(self._on_prep_finished)
+        self.prep_worker.failed.connect(self._on_prep_failed)
+        self.prep_worker.start.emit()
+
+    # -- layout: preparation view -----------------------------------------
+
+    def _layout_progress(self):
+        widget = QWidget()
+        layout = QGridLayout(widget)
+
+        try:
+            cover_image = self.api.cover(self.ebook.id, as_pixmap=True)
+        except Exception:
+            cover_image = QPixmap(
+                self.api.cover(self.ebook.id, as_image=True))
+        if cover_image is None or cover_image.isNull():
+            cover_image = QPixmap(I('default_cover.png'))
+        cover_image = cover_image.scaledToHeight(
+            400, Qt.TransformationMode.SmoothTransformation)
+
+        cover = QLabel()
+        cover.setAlignment(Qt.AlignCenter)
+        cover.setPixmap(cover_image)
+
+        title = QLabel(self.ebook.title)
+        title.setAlignment(Qt.AlignCenter)
+        title.setStyleSheet('font-weight:bold;font-size:16px;')
+
+        progress_bar = QProgressBar()
+        progress_bar.setRange(0, 0)  # indeterminate
+        progress_bar.setValue(0)
+
+        self._prep_label = QLabel(_('Loading ebook data, please wait...'))
+        self._prep_label.setAlignment(Qt.AlignCenter)
+
+        self._prep_detail = QPlainTextEdit()
+        self._prep_detail.setReadOnly(True)
+
+        layout.addWidget(cover, 0, 0)
+        layout.addWidget(title, 1, 0)
+        layout.addItem(QSpacerItem(0, 20), 2, 0)
+        layout.addWidget(progress_bar, 3, 0)
+        layout.addWidget(self._prep_label, 4, 0)
+        layout.addItem(QSpacerItem(10, 0), 0, 1, 6, 1)
+        layout.addWidget(self._prep_detail, 0, 2, 6, 1)
+        layout.setRowStretch(2, 1)
+        layout.setColumnStretch(2, 1)
+
+        return widget
+
+    # -- prep -> main transition ------------------------------------------
+
+    @pyqtSlot(str, object)
+    def _on_prep_finished(self, cache_id, chapters_meta):
+        self.cache_id = cache_id
+        self.chapters_meta = chapters_meta or []
+        if not self.chapters_meta:
+            self.alert.pop(
+                _('No translatable content detected in this book.'),
+                'warning')
+            self.done(0)
+            return
+        self.main_panel = self._layout_main()
+        self.stack.addWidget(self.main_panel)
+        self.stack.setCurrentWidget(self.main_panel)
+        self._refresh_chapter_list_from_cache()
+
+    @pyqtSlot(str)
+    def _on_prep_failed(self, message):
+        self.alert.pop(
+            _('Failed to prepare novel mode: {}').format(message), 'error')
+        self.done(0)
+
+    # -- layout: main view -------------------------------------------------
+
+    def _layout_main(self):
+        widget = QWidget()
+        outer = QVBoxLayout(widget)
+
+        splitter = QSplitter(Qt.Orientation.Horizontal)
+
+        # Left side: chapter list.
+        left = QWidget()
+        left_layout = QVBoxLayout(left)
+        left_layout.setContentsMargins(0, 0, 0, 0)
+        left_layout.addWidget(QLabel(_('Chapters')))
+        self.chapter_list = QListWidget()
+        for ch in self.chapters_meta:
+            item = QListWidgetItem(self._chapter_label(ch, self.STATUS_PENDING))
+            item.setData(Qt.UserRole, ch['index'])
+            self.chapter_list.addItem(item)
+            self.chapter_items[ch['index']] = item
+            self.status_by_chapter[ch['index']] = self.STATUS_PENDING
+        left_layout.addWidget(self.chapter_list, 1)
+
+        # Right side: progress + tabs.
+        right = QWidget()
+        right_layout = QVBoxLayout(right)
+        right_layout.setContentsMargins(0, 0, 0, 0)
+
+        # Info line.
+        info_row = QHBoxLayout()
+        info_row.addWidget(QLabel('%s: %s' % (_('Engine'),
+                                              self.current_engine.name)))
+        info_row.addWidget(QLabel('%s: %s' % (_('Target'),
+                                              self.ebook.target_lang)))
+        info_row.addStretch(1)
+        right_layout.addLayout(info_row)
+
+        # Progress bar + status label.
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setRange(0, 100)
+        self.progress_bar.setValue(0)
+        right_layout.addWidget(self.progress_bar)
+        self.progress_label = QLabel(_('Ready.'))
+        right_layout.addWidget(self.progress_label)
+
+        # Tabs.
+        self.tabs = QTabWidget()
+
+        # Summaries tab.
+        self.summaries_view = QPlainTextEdit()
+        self.summaries_view.setReadOnly(True)
+        self.tabs.addTab(self.summaries_view, _('Summaries'))
+
+        # Glossary tab.
+        self.glossary_table = QTableWidget()
+        self.glossary_table.setColumnCount(4)
+        self.glossary_table.setHorizontalHeaderLabels(
+            [_('Source'), _('Translation'), _('Type'), _('Notes')])
+        self.glossary_table.horizontalHeader().setSectionResizeMode(
+            QHeaderView.ResizeMode.Stretch)
+        self.tabs.addTab(self.glossary_table, _('Glossary'))
+        glossary_actions = QHBoxLayout()
+        save_glossary_btn = QPushButton(_('Save edits'))
+        save_glossary_btn.clicked.connect(self._save_glossary_edits)
+        reset_glossary_btn = QPushButton(_('Reset context'))
+        reset_glossary_btn.clicked.connect(self._reset_context)
+        glossary_actions.addWidget(save_glossary_btn)
+        glossary_actions.addWidget(reset_glossary_btn)
+        glossary_actions.addStretch(1)
+        glossary_wrap = QWidget()
+        glossary_wrap_layout = QVBoxLayout(glossary_wrap)
+        glossary_wrap_layout.setContentsMargins(0, 0, 0, 0)
+        glossary_wrap_layout.addWidget(self.glossary_table, 1)
+        glossary_wrap_layout.addLayout(glossary_actions)
+        # Replace the tab widget with the wrapper.
+        self.tabs.removeTab(1)
+        self.tabs.insertTab(1, glossary_wrap, _('Glossary'))
+
+        # Log tab.
+        self.log_view = QPlainTextEdit()
+        self.log_view.setReadOnly(True)
+        self.tabs.addTab(self.log_view, _('Log'))
+
+        right_layout.addWidget(self.tabs, 1)
+
+        splitter.addWidget(left)
+        splitter.addWidget(right)
+        splitter.setStretchFactor(0, 1)
+        splitter.setStretchFactor(1, 3)
+
+        outer.addWidget(splitter, 1)
+
+        # Buttons row.
+        btn_row = QHBoxLayout()
+        self.start_button = QPushButton(_('Start / Resume'))
+        self.start_button.clicked.connect(self._on_start)
+        self.cancel_button = QPushButton(_('Cancel'))
+        self.cancel_button.clicked.connect(self._on_cancel)
+        self.cancel_button.setEnabled(False)
+        self.output_button = QPushButton(_('Build translated ebook'))
+        self.output_button.setEnabled(False)
+        self.output_button.clicked.connect(self._on_build_output)
+        self.close_button = QPushButton(_('Close'))
+        self.close_button.clicked.connect(lambda: self.done(0))
+        btn_row.addWidget(self.start_button)
+        btn_row.addWidget(self.cancel_button)
+        btn_row.addStretch(1)
+        btn_row.addWidget(self.output_button)
+        btn_row.addWidget(self.close_button)
+        outer.addLayout(btn_row)
+
+        return widget
+
+    # -- chapter list rendering -------------------------------------------
+
+    _STATUS_SYMBOL = {
+        STATUS_PENDING: '•',
+        STATUS_RUNNING: '▶',
+        STATUS_DONE: '✓',
+        STATUS_ERROR: '✗',
+    }
+    _STATUS_COLOR = {
+        STATUS_PENDING: None,
+        STATUS_RUNNING: '#4169e1',   # royalblue
+        STATUS_DONE: '#2e8b57',      # seagreen
+        STATUS_ERROR: '#dc143c',     # crimson
+    }
+
+    def _chapter_label(self, chapter_meta, status):
+        symbol = self._STATUS_SYMBOL.get(status, '•')
+        return '%s  %d. %s' % (
+            symbol, chapter_meta['index'], chapter_meta['title'] or '?')
+
+    def _set_chapter_status(self, index, status):
+        self.status_by_chapter[index] = status
+        item = self.chapter_items.get(index)
+        if item is None:
+            return
+        meta = next((m for m in self.chapters_meta
+                     if m['index'] == index), None)
+        if meta is None:
+            return
+        item.setText(self._chapter_label(meta, status))
+        color_hex = self._STATUS_COLOR.get(status)
+        if color_hex:
+            item.setForeground(QColor(color_hex))
+
+    def _refresh_chapter_list_from_cache(self):
+        """Restore chapter statuses from cache progress (for resume)."""
+        cache = get_cache(self.cache_id)
+        try:
+            progress = int(cache.get_info('novel_progress') or 0)
+        except (ValueError, TypeError):
+            progress = 0
+        for meta in self.chapters_meta:
+            if meta['index'] <= progress:
+                self._set_chapter_status(meta['index'], self.STATUS_DONE)
+        self._refresh_context_views(cache)
+        cache.close()
+
+        completed = sum(1 for s in self.status_by_chapter.values()
+                        if s == self.STATUS_DONE)
+        total = len(self.chapters_meta)
+        pct = int(100 * completed / max(1, total))
+        self.progress_bar.setValue(pct)
+        self.progress_label.setText(_(
+            '{done}/{total} chapters done.').format(
+                done=completed, total=total))
+        if completed >= total > 0:
+            self.output_button.setEnabled(True)
+            self.start_button.setText(_('Re-run all'))
+
+    def _refresh_context_views(self, cache=None):
+        should_close = False
+        if cache is None:
+            cache = get_cache(self.cache_id)
+            should_close = True
+        try:
+            import json as _json
+            raw = cache.get_info('novel_summaries')
+            summaries = []
+            try:
+                summaries = _json.loads(raw) if raw else []
+            except (ValueError, TypeError):
+                summaries = []
+            self.summaries_view.clear()
+            for s in summaries:
+                self.summaries_view.appendPlainText(
+                    '=== %s: %s ===' % (
+                        _('Chapter {}').format(s.get('chapter', '?')),
+                        s.get('title', '')))
+                self.summaries_view.appendPlainText(s.get('summary', ''))
+                self.summaries_view.appendPlainText('')
+
+            raw = cache.get_info('novel_glossary')
+            glossary = {}
+            try:
+                glossary = _json.loads(raw) if raw else {}
+            except (ValueError, TypeError):
+                glossary = {}
+            self.glossary_table.setRowCount(len(glossary))
+            for row, (source, entry) in enumerate(glossary.items()):
+                self.glossary_table.setItem(
+                    row, 0, QTableWidgetItem(source))
+                self.glossary_table.setItem(
+                    row, 1, QTableWidgetItem(entry.get('translation', '')))
+                self.glossary_table.setItem(
+                    row, 2, QTableWidgetItem(entry.get('type', '')))
+                self.glossary_table.setItem(
+                    row, 3, QTableWidgetItem(entry.get('notes', '')))
+        finally:
+            if should_close:
+                cache.close()
+
+    # -- controls ----------------------------------------------------------
+
+    def _on_start(self):
+        # Sanity: engine must still support novel mode (user may have
+        # changed it in Setting).
+        self.current_engine = get_engine_class()
+        if not getattr(self.current_engine, 'supports_novel_mode', False):
+            self.alert.pop(_(
+                'Novel mode requires a GenAI engine. Please choose one '
+                'in Setting.'), 'warning')
+            return
+        self._start_translation_worker()
+
+    def _start_translation_worker(self):
+        # Terminate any previous worker: disconnect its signals so we don't
+        # accidentally receive events for it after we start a new one.
+        if self.trans_worker is not None:
+            try:
+                self.trans_worker.logging.disconnect()
+                self.trans_worker.progress.disconnect()
+                self.trans_worker.chapter_started.disconnect()
+                self.trans_worker.chapter_done.disconnect()
+                self.trans_worker.finished.disconnect()
+            except (RuntimeError, TypeError):
+                pass
+            try:
+                self.trans_worker.deleteLater()
+            except RuntimeError:
+                pass
+        if not self.trans_thread.isRunning():
+            self.trans_thread.start()
+        self.trans_worker = NovelTranslationWorker(
+            self.current_engine, self.ebook, self.cache_id)
+        self.trans_worker.moveToThread(self.trans_thread)
+        self.trans_worker.logging.connect(self._on_log)
+        self.trans_worker.progress.connect(self._on_progress)
+        self.trans_worker.chapter_started.connect(
+            lambda idx: self._set_chapter_status(idx, self.STATUS_RUNNING))
+        self.trans_worker.chapter_done.connect(self._on_chapter_done)
+        self.trans_worker.finished.connect(self._on_worker_finished)
+        self.start_button.setEnabled(False)
+        self.cancel_button.setEnabled(True)
+        self.output_button.setEnabled(False)
+        self.trans_worker.start.emit()
+
+    def _on_cancel(self):
+        if self.trans_worker is None:
+            return
+        self.trans_worker.set_canceled(True)
+        self.cancel_button.setEnabled(False)
+        self.progress_label.setText(_('Cancel requested...'))
+
+    def _on_log(self, text, is_error):
+        prefix = '[ERROR] ' if is_error else ''
+        self.log_view.appendPlainText(prefix + text)
+
+    def _on_progress(self, fraction, message):
+        try:
+            self.progress_bar.setValue(int(100 * float(fraction)))
+        except (TypeError, ValueError):
+            pass
+        if message:
+            self.progress_label.setText(message)
+
+    def _on_chapter_done(self, index, summary, glossary_delta):
+        self._set_chapter_status(index, self.STATUS_DONE)
+        self._refresh_context_views()
+
+    def _on_worker_finished(self, success, message):
+        self.start_button.setEnabled(True)
+        self.cancel_button.setEnabled(False)
+        self.progress_label.setText(message)
+        # Any chapter still marked "running" is now uncertain: leave as-is.
+        if success:
+            # Enable output only if all chapters are done.
+            done_count = sum(
+                1 for s in self.status_by_chapter.values()
+                if s == self.STATUS_DONE)
+            if done_count >= len(self.chapters_meta):
+                self.output_button.setEnabled(True)
+                self.alert.pop(_(
+                    'Novel mode: all chapters translated. Click '
+                    '"Build translated ebook" to produce the output.'))
+        else:
+            self.alert.pop(message, 'warning')
+
+    # -- glossary editing --------------------------------------------------
+
+    def _save_glossary_edits(self):
+        import json as _json
+        new_glossary = {}
+        for row in range(self.glossary_table.rowCount()):
+            def _cell(col):
+                item = self.glossary_table.item(row, col)
+                return (item.text() if item else '').strip()
+            source = _cell(0)
+            translation = _cell(1)
+            if not source or not translation:
+                continue
+            new_glossary[source] = {
+                'translation': translation,
+                'type': _cell(2),
+                'notes': _cell(3),
+            }
+        cache = get_cache(self.cache_id)
+        try:
+            cache.set_info(
+                'novel_glossary',
+                _json.dumps(new_glossary, ensure_ascii=False))
+        finally:
+            cache.close()
+        self.alert.pop(_('Glossary saved.'))
+
+    def _reset_context(self):
+        ret = QMessageBox.question(
+            self, _('Reset context'),
+            _('This will discard all summaries and the glossary, and reset '
+              'chapter progress to 0. The already-translated paragraphs '
+              'will remain in cache. Continue?'),
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
+        if ret != QMessageBox.StandardButton.Yes:
+            return
+        cache = get_cache(self.cache_id)
+        try:
+            ContextManager(cache).load().reset()
+        finally:
+            cache.close()
+        for idx in list(self.status_by_chapter.keys()):
+            self._set_chapter_status(idx, self.STATUS_PENDING)
+        self.progress_bar.setValue(0)
+        self.output_button.setEnabled(False)
+        self._refresh_context_views()
+
+    # -- final ebook build -------------------------------------------------
+
+    def _on_build_output(self):
+        # Reuse ConversionWorker.translate_ebook_novel with cache_only=True:
+        # the cache is already fully populated by the interactive pipeline,
+        # so this will just re-emit the DOM through Plumber. Uses a
+        # dedicated ``convert_item_novel`` entry point (see lib/conversion.py)
+        # to avoid colliding with the classic pipeline's argument layout.
+        try:
+            self.ebook.set_output_format(
+                self.ebook.output_format or 'epub')
+            self.worker.translate_ebook_novel(
+                self.ebook, cache_only=True)
+            self.alert.pop(_(
+                'Building translated ebook in background. Watch the '
+                'jobs panel for progress.'))
+        except Exception as e:
+            self.alert.pop(
+                _('Failed to launch build job: {}').format(e), 'error')

--- a/setting.py
+++ b/setting.py
@@ -584,10 +584,40 @@ class TranslationSetting(QDialog):
         novel_chapter_source.addItem(
             _('Table of Contents (level 1)'), 'toc_level_1')
         novel_chapter_source.addItem(
+            _('Table of Contents (level 2)'), 'toc_level_2')
+        novel_chapter_source.addItem(
             _('One XHTML file per chapter'), 'xhtml_file')
+        novel_chapter_source.setToolTip(_(
+            'How to detect chapter boundaries.\n\n'
+            '- TOC level 1: use the top-level Table of Contents entries as '
+            'chapter boundaries. Best for single-book EPUBs.\n'
+            '- TOC level 2: use the second-level TOC entries (sub-chapters). '
+            'Recommended for multi-book anthologies (e.g. a complete series '
+            'in one EPUB) where level 1 maps each full novel to a single '
+            '"chapter". Level 2 maps individual chapters, giving the LLM '
+            'the correct chapter title and preventing front-matter pages '
+            '(Cover, Titlepage) from polluting the first translation chunk.\n'
+            '- One XHTML file: each XHTML file in the spine becomes one '
+            'chapter. Useful when the TOC is missing or unreliable.'))
         novel_layout.addRow(
             _('Chapter detection'), novel_chapter_source)
         self.disable_wheel_event(novel_chapter_source)
+
+        novel_front_matter_min = QSpinBox()
+        novel_front_matter_min.setRange(0, 5000)
+        novel_front_matter_min.setSingleStep(50)
+        novel_front_matter_min.setToolTip(_(
+            'XHTML pages whose total text content is shorter than this '
+            'many characters are treated as front/back matter (Cover, '
+            'Titlepage, decorative pages) and excluded from chapter '
+            'narrative content. Their paragraphs are still translated by '
+            'the auxiliary pipeline (metadata/TOC titles).\n\n'
+            'A typical Titlepage in a multi-book anthology contains only '
+            'the book title as a single heading (~25 chars) -- well below '
+            'the default of 100. Set to 0 to include all pages.'))
+        novel_layout.addRow(
+            _('Skip front matter under (chars)'), novel_front_matter_min)
+        self.disable_wheel_event(novel_front_matter_min)
 
         novel_chunk_tokens = QSpinBox()
         novel_chunk_tokens.setRange(1024, 200000)
@@ -605,17 +635,58 @@ class TranslationSetting(QDialog):
         novel_max_paragraphs.setSingleStep(10)
         novel_max_paragraphs.setToolTip(_(
             'Maximum number of paragraphs per translation chunk. '
-            'Prevents the LLM from losing track of the <Pn>...</Pn> '
-            'alignment markers when paragraphs are short (dialogue, '
-            'TOC lists). The chunk is closed as soon as either the '
-            'token budget or this paragraph cap is reached, whichever '
-            'comes first.\n\n'
-            'Recommended: 40 for small models (7B), 60 for medium (26B '
+            'Prevents the LLM from losing track of the [N] alignment '
+            'markers when paragraphs are short (dialogue, TOC lists). '
+            'The chunk is closed as soon as either the token budget or '
+            'this paragraph cap is reached, whichever comes first.\n\n'
+            'Recommended: 40 for small models (7B), 80 for medium (26B '
             'like gemma), 100+ for large models (Claude, GPT-4). '
             'Set to 0 to disable and use only the token budget.'))
         novel_layout.addRow(
             _('Max paragraphs per chunk'), novel_max_paragraphs)
         self.disable_wheel_event(novel_max_paragraphs)
+
+        novel_overlap = QSpinBox()
+        novel_overlap.setRange(0, 50)
+        novel_overlap.setSingleStep(1)
+        novel_overlap.setToolTip(_(
+            'Number of already-translated paragraphs from the previous '
+            'chunk to replay as context for the next chunk. Similar to '
+            'the sliding-window overlap used in RAG chunking, this '
+            'preserves dialogue threads, pronoun referents and stylistic '
+            'continuity across chunk boundaries. The overlap paragraphs '
+            'are shown to the LLM as already-translated text (do NOT '
+            'retranslate), so they consume some of the token budget but '
+            'do not cause double translations.\n\n'
+            'Recommended: 3 for most novels; 5-10 for dense narrative '
+            'with long scenes. Set to 0 to disable overlap.'))
+        novel_layout.addRow(
+            _('Overlap paragraphs'), novel_overlap)
+        self.disable_wheel_event(novel_overlap)
+
+        novel_structured = QComboBox()
+        novel_structured.addItem(_('Auto (recommended)'), 'auto')
+        novel_structured.addItem(_('Off (text markers [N])'), 'off')
+        novel_structured.addItem(_('Force JSON on any engine'), 'force')
+        novel_structured.setToolTip(_(
+            'How to format the LLM response for paragraph alignment.\n\n'
+            '- Auto: use native JSON structured output when the engine '
+            'supports it (ChatGPT, Gemini, Ollama via OpenAI-compatible '
+            'endpoint). Falls back to text markers [N] otherwise. '
+            'Recommended.\n'
+            '- Off: always use text markers [N]. Slightly less reliable '
+            'above 60-80 paragraphs per chunk on medium models but '
+            'works everywhere.\n'
+            '- Force: always request JSON output, even from engines that '
+            'do not advertise support. Useful for custom OpenAI-compatible '
+            'endpoints (Ollama exotics, LM Studio, vLLM) that accept '
+            '"response_format" but are not recognised by the plugin.\n\n'
+            'With structured output active you can safely raise '
+            '"Max paragraphs per chunk" to 80+ without markers being '
+            'dropped by the model.'))
+        novel_layout.addRow(
+            _('Structured output'), novel_structured)
+        self.disable_wheel_event(novel_structured)
 
         novel_context_tokens = QSpinBox()
         novel_context_tokens.setRange(0, 100000)
@@ -676,10 +747,19 @@ class TranslationSetting(QDialog):
             idx = novel_chapter_source.findData(src)
             if idx >= 0:
                 novel_chapter_source.setCurrentIndex(idx)
+            novel_front_matter_min.setValue(int(self.config.get(
+                'novel_front_matter_min_chars', 100) or 0))
             novel_chunk_tokens.setValue(int(self.config.get(
                 'novel_chunk_tokens', 12000) or 12000))
             novel_max_paragraphs.setValue(int(self.config.get(
-                'novel_max_paragraphs_per_chunk', 60) or 0))
+                'novel_max_paragraphs_per_chunk', 80) or 0))
+            novel_overlap.setValue(int(self.config.get(
+                'novel_overlap_paragraphs', 3) or 0))
+            structured_mode = self.config.get(
+                'novel_structured_output', 'auto') or 'auto'
+            idx = novel_structured.findData(structured_mode)
+            if idx >= 0:
+                novel_structured.setCurrentIndex(idx)
             novel_context_tokens.setValue(int(self.config.get(
                 'novel_context_tokens', 1500) or 1500))
             novel_summary_tokens.setValue(int(self.config.get(
@@ -713,10 +793,17 @@ class TranslationSetting(QDialog):
         novel_chapter_source.currentIndexChanged.connect(
             lambda _idx: self.config.update(
                 novel_chapter_source=novel_chapter_source.currentData()))
+        novel_front_matter_min.valueChanged.connect(
+            _persist_novel('novel_front_matter_min_chars', int))
         novel_chunk_tokens.valueChanged.connect(
             _persist_novel('novel_chunk_tokens', int))
         novel_max_paragraphs.valueChanged.connect(
             _persist_novel('novel_max_paragraphs_per_chunk', int))
+        novel_overlap.valueChanged.connect(
+            _persist_novel('novel_overlap_paragraphs', int))
+        novel_structured.currentIndexChanged.connect(
+            lambda _idx: self.config.update(
+                novel_structured_output=novel_structured.currentData()))
         novel_context_tokens.valueChanged.connect(
             _persist_novel('novel_context_tokens', int))
         novel_summary_tokens.valueChanged.connect(

--- a/setting.py
+++ b/setting.py
@@ -154,27 +154,30 @@ class TranslationSetting(QDialog):
         mode_layout = QGridLayout(mode_group)
         advanced_mode = QRadioButton(_('Advanced Mode'))
         batch_mode = QRadioButton(_('Batch Mode'))
+        novel_mode = QRadioButton(_('Novel Mode'))
         icon_button = QLabel()
         icon_button.setPixmap(self.icon.pixmap(52, 52))
         mode_layout.addWidget(icon_button, 0, 0, 3, 1)
         mode_layout.addWidget(advanced_mode, 0, 1)
         mode_layout.addWidget(batch_mode, 0, 2)
-        mode_layout.addItem(QSpacerItem(0, 0), 0, 3)
+        mode_layout.addWidget(novel_mode, 0, 3)
+        mode_layout.addItem(QSpacerItem(0, 0), 0, 4)
         mode_layout.addWidget(self._divider(), 1, 1, 1, 4)
         mode_layout.addWidget(QLabel(
             _('Choose a translation mode for clicking the icon button.')),
             2, 1, 1, 4)
-        mode_layout.setColumnStretch(3, 1)
+        mode_layout.setColumnStretch(4, 1)
         layout.addWidget(mode_group)
 
-        mode_map = dict(enumerate(['advanced', 'batch']))
+        mode_map = dict(enumerate(['advanced', 'batch', 'novel']))
         mode_rmap = dict((v, k) for k, v in mode_map.items())
         mode_btn_group = QButtonGroup(mode_group)
         mode_btn_group.addButton(advanced_mode, 0)
         mode_btn_group.addButton(batch_mode, 1)
+        mode_btn_group.addButton(novel_mode, 2)
 
         preferred_mode = self.config.get('preferred_mode')
-        if preferred_mode is not None:
+        if preferred_mode is not None and preferred_mode in mode_rmap:
             mode_btn_group.button(
                 mode_rmap.get(preferred_mode)).setChecked(True)
         mode_btn_group.idClicked.connect(
@@ -571,6 +574,150 @@ class TranslationSetting(QDialog):
 
         layout.addWidget(genai_group)
 
+        # Novel Mode settings (visible only for GenAI engines).
+        novel_group = QGroupBox(_('Novel Mode'))
+        novel_group.setVisible(False)
+        novel_layout = QFormLayout(novel_group)
+        self.apply_form_layout_policy(novel_layout)
+
+        novel_chapter_source = QComboBox()
+        novel_chapter_source.addItem(
+            _('Table of Contents (level 1)'), 'toc_level_1')
+        novel_chapter_source.addItem(
+            _('One XHTML file per chapter'), 'xhtml_file')
+        novel_layout.addRow(
+            _('Chapter detection'), novel_chapter_source)
+        self.disable_wheel_event(novel_chapter_source)
+
+        novel_chunk_tokens = QSpinBox()
+        novel_chunk_tokens.setRange(1024, 200000)
+        novel_chunk_tokens.setSingleStep(1024)
+        novel_layout.addRow(
+            _('Chunk size (tokens)'), novel_chunk_tokens)
+        self.disable_wheel_event(novel_chunk_tokens)
+
+        novel_context_tokens = QSpinBox()
+        novel_context_tokens.setRange(0, 100000)
+        novel_context_tokens.setSingleStep(256)
+        novel_layout.addRow(
+            _('Reserved for context (tokens)'), novel_context_tokens)
+        self.disable_wheel_event(novel_context_tokens)
+
+        novel_summary_tokens = QSpinBox()
+        novel_summary_tokens.setRange(50, 5000)
+        novel_summary_tokens.setSingleStep(50)
+        novel_layout.addRow(
+            _('Summary target size (tokens)'), novel_summary_tokens)
+        self.disable_wheel_event(novel_summary_tokens)
+
+        novel_glossary_max = QSpinBox()
+        novel_glossary_max.setRange(10, 5000)
+        novel_glossary_max.setSingleStep(10)
+        novel_layout.addRow(
+            _('Glossary max entries'), novel_glossary_max)
+        self.disable_wheel_event(novel_glossary_max)
+
+        novel_min_chars = QSpinBox()
+        novel_min_chars.setRange(0, 100000)
+        novel_min_chars.setSingleStep(50)
+        novel_min_chars.setToolTip(_(
+            'Chapters shorter than this many translated characters skip '
+            'the summary and glossary LLM calls. Useful to avoid wasting '
+            'time on Copyright, Table of Contents, About the Author, '
+            'etc. Set to 0 to always run summary/glossary.'))
+        novel_layout.addRow(
+            _('Skip context under (chars)'), novel_min_chars)
+        self.disable_wheel_event(novel_min_chars)
+
+        novel_translation_prompt = QPlainTextEdit()
+        novel_translation_prompt.setFixedHeight(90)
+        novel_layout.addRow(
+            _('Translation prompt'), novel_translation_prompt)
+        novel_summary_prompt = QPlainTextEdit()
+        novel_summary_prompt.setFixedHeight(70)
+        novel_layout.addRow(
+            _('Summary prompt'), novel_summary_prompt)
+        novel_glossary_prompt = QPlainTextEdit()
+        novel_glossary_prompt.setFixedHeight(70)
+        novel_layout.addRow(
+            _('Glossary prompt'), novel_glossary_prompt)
+
+        layout.addWidget(novel_group)
+
+        # Wire novel settings to config on change.
+        def load_novel_settings():
+            from .lib.novel import (
+                DEFAULT_NOVEL_TRANSLATION_PROMPT,
+                DEFAULT_NOVEL_SUMMARY_PROMPT,
+                DEFAULT_NOVEL_GLOSSARY_PROMPT)
+            src = self.config.get(
+                'novel_chapter_source', 'toc_level_1') or 'toc_level_1'
+            idx = novel_chapter_source.findData(src)
+            if idx >= 0:
+                novel_chapter_source.setCurrentIndex(idx)
+            novel_chunk_tokens.setValue(int(self.config.get(
+                'novel_chunk_tokens', 8000) or 8000))
+            novel_context_tokens.setValue(int(self.config.get(
+                'novel_context_tokens', 1500) or 1500))
+            novel_summary_tokens.setValue(int(self.config.get(
+                'novel_summary_tokens', 400) or 400))
+            novel_glossary_max.setValue(int(self.config.get(
+                'novel_glossary_max_entries', 200) or 200))
+            novel_min_chars.setValue(int(self.config.get(
+                'novel_min_chars_for_context', 300) or 0))
+            novel_translation_prompt.setPlaceholderText(
+                DEFAULT_NOVEL_TRANSLATION_PROMPT)
+            novel_translation_prompt.setPlainText(
+                self.config.get('novel_translation_prompt') or '')
+            novel_summary_prompt.setPlaceholderText(
+                DEFAULT_NOVEL_SUMMARY_PROMPT)
+            novel_summary_prompt.setPlainText(
+                self.config.get('novel_summary_prompt') or '')
+            novel_glossary_prompt.setPlaceholderText(
+                DEFAULT_NOVEL_GLOSSARY_PROMPT)
+            novel_glossary_prompt.setPlainText(
+                self.config.get('novel_glossary_prompt') or '')
+        load_novel_settings()
+
+        def _persist_novel(key, cast):
+            def _handler(value):
+                try:
+                    self.config.update(**{key: cast(value)})
+                except (ValueError, TypeError):
+                    pass
+            return _handler
+
+        novel_chapter_source.currentIndexChanged.connect(
+            lambda _idx: self.config.update(
+                novel_chapter_source=novel_chapter_source.currentData()))
+        novel_chunk_tokens.valueChanged.connect(
+            _persist_novel('novel_chunk_tokens', int))
+        novel_context_tokens.valueChanged.connect(
+            _persist_novel('novel_context_tokens', int))
+        novel_summary_tokens.valueChanged.connect(
+            _persist_novel('novel_summary_tokens', int))
+        novel_glossary_max.valueChanged.connect(
+            _persist_novel('novel_glossary_max_entries', int))
+        novel_min_chars.valueChanged.connect(
+            _persist_novel('novel_min_chars_for_context', int))
+
+        def _persist_prompt(widget, key):
+            def _handler():
+                text = widget.toPlainText().strip()
+                if text:
+                    self.config.update(**{key: text})
+                else:
+                    self.config.delete(key)
+            return _handler
+
+        novel_translation_prompt.textChanged.connect(
+            _persist_prompt(
+                novel_translation_prompt, 'novel_translation_prompt'))
+        novel_summary_prompt.textChanged.connect(
+            _persist_prompt(novel_summary_prompt, 'novel_summary_prompt'))
+        novel_glossary_prompt.textChanged.connect(
+            _persist_prompt(novel_glossary_prompt, 'novel_glossary_prompt'))
+
         # Setup genAI model
         def init_ai_models(model=None):
             if not issubclass(self.current_engine, GenAI):
@@ -760,8 +907,10 @@ class TranslationSetting(QDialog):
                 lambda value: config.update(max_error_count=value))
             # Show GenAI preferences
             genai_group.setVisible(False)
+            novel_group.setVisible(False)
             if issubclass(self.current_engine, GenAI):
                 genai_group.setVisible(True)
+                novel_group.setVisible(True)
                 show_genai_preferences(config)
         choose_default_engine(engine_list.findData(self.current_engine.name))
         engine_list.currentIndexChanged.connect(choose_default_engine)

--- a/setting.py
+++ b/setting.py
@@ -592,9 +592,30 @@ class TranslationSetting(QDialog):
         novel_chunk_tokens = QSpinBox()
         novel_chunk_tokens.setRange(1024, 200000)
         novel_chunk_tokens.setSingleStep(1024)
+        novel_chunk_tokens.setToolTip(_(
+            'Maximum estimated tokens per translation chunk. Together '
+            'with "Max paragraphs per chunk" it forms a dual-cap: the '
+            'chunk is closed as soon as either limit is reached.'))
         novel_layout.addRow(
-            _('Chunk size (tokens)'), novel_chunk_tokens)
+            _('Max tokens per chunk'), novel_chunk_tokens)
         self.disable_wheel_event(novel_chunk_tokens)
+
+        novel_max_paragraphs = QSpinBox()
+        novel_max_paragraphs.setRange(0, 500)
+        novel_max_paragraphs.setSingleStep(10)
+        novel_max_paragraphs.setToolTip(_(
+            'Maximum number of paragraphs per translation chunk. '
+            'Prevents the LLM from losing track of the <Pn>...</Pn> '
+            'alignment markers when paragraphs are short (dialogue, '
+            'TOC lists). The chunk is closed as soon as either the '
+            'token budget or this paragraph cap is reached, whichever '
+            'comes first.\n\n'
+            'Recommended: 40 for small models (7B), 60 for medium (26B '
+            'like gemma), 100+ for large models (Claude, GPT-4). '
+            'Set to 0 to disable and use only the token budget.'))
+        novel_layout.addRow(
+            _('Max paragraphs per chunk'), novel_max_paragraphs)
+        self.disable_wheel_event(novel_max_paragraphs)
 
         novel_context_tokens = QSpinBox()
         novel_context_tokens.setRange(0, 100000)
@@ -656,7 +677,9 @@ class TranslationSetting(QDialog):
             if idx >= 0:
                 novel_chapter_source.setCurrentIndex(idx)
             novel_chunk_tokens.setValue(int(self.config.get(
-                'novel_chunk_tokens', 8000) or 8000))
+                'novel_chunk_tokens', 12000) or 12000))
+            novel_max_paragraphs.setValue(int(self.config.get(
+                'novel_max_paragraphs_per_chunk', 60) or 0))
             novel_context_tokens.setValue(int(self.config.get(
                 'novel_context_tokens', 1500) or 1500))
             novel_summary_tokens.setValue(int(self.config.get(
@@ -692,6 +715,8 @@ class TranslationSetting(QDialog):
                 novel_chapter_source=novel_chapter_source.currentData()))
         novel_chunk_tokens.valueChanged.connect(
             _persist_novel('novel_chunk_tokens', int))
+        novel_max_paragraphs.valueChanged.connect(
+            _persist_novel('novel_max_paragraphs_per_chunk', int))
         novel_context_tokens.valueChanged.connect(
             _persist_novel('novel_context_tokens', int))
         novel_summary_tokens.valueChanged.connect(

--- a/tests/lib/test_element.py
+++ b/tests/lib/test_element.py
@@ -740,6 +740,102 @@ epub:type="pagebreak"/>b</code></p></body>
         self.assertEqual('abc', a.get('href'))
         self.assertEqual('A', a.text)
 
+    def test_add_translation_only_preserves_nested_links(self):
+        """position='only' on a <nav>/<ol>/<li> with nested <a href> must
+        keep the href attributes so TOC navigation survives translation."""
+        xhtml = etree.XML(rb"""<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+    <head><title>Test</title></head>
+    <body>
+        <ol>
+            <li><a href="ch1.xhtml">Chapter One</a></li>
+            <li><a href="ch2.xhtml">Chapter Two</a></li>
+        </ol>
+    </body>
+</html>""")
+        ol = xhtml.find('.//x:ol', namespaces=ns)
+        element = PageElement(ol, 'p1')
+        element.position = 'only'
+        element.set_placeholder(Base.placeholder)
+        element.set_remove_pattern(None)
+        element.set_reserve_pattern(None)
+        element.get_content()
+        element.add_translation('Capitolo Uno\nCapitolo Due')
+
+        # After only-mode replacement the <ol> must still be present.
+        new_ol = xhtml.find('.//x:ol', namespaces=ns)
+        self.assertIsNotNone(new_ol)
+
+        # Both <a> elements must survive with their original hrefs.
+        links = xhtml.findall('.//x:a', namespaces=ns)
+        self.assertEqual(2, len(links))
+        hrefs = [a.get('href') for a in links]
+        self.assertIn('ch1.xhtml', hrefs)
+        self.assertIn('ch2.xhtml', hrefs)
+
+        # The text of the links must be the translated version.
+        texts = [a.text for a in links]
+        self.assertTrue(
+            any(t and ('Capitolo' in t or 'Uno' in t) for t in texts),
+            'At least one translated text expected, got: %s' % texts)
+
+    def test_add_translation_only_li_preserves_link(self):
+        """position='only' on a <li> with a nested <a href> must keep the
+        href (TOC list item)."""
+        xhtml = etree.XML(rb"""<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+    <head><title>Test</title></head>
+    <body>
+        <ul>
+            <li><a href="ch3.xhtml">Chapter Three</a></li>
+        </ul>
+    </body>
+</html>""")
+        li = xhtml.find('.//x:li', namespaces=ns)
+        element = PageElement(li, 'p1')
+        element.position = 'only'
+        element.set_placeholder(Base.placeholder)
+        element.set_remove_pattern(None)
+        element.set_reserve_pattern(None)
+        element.get_content()
+        element.add_translation('Capitolo Tre')
+
+        new_li = xhtml.find('.//x:li', namespaces=ns)
+        self.assertIsNotNone(new_li)
+        a = xhtml.find('.//x:a', namespaces=ns)
+        self.assertIsNotNone(a)
+        self.assertEqual('ch3.xhtml', a.get('href'))
+
+    def test_add_translation_only_no_links_unchanged(self):
+        """position='only' on a plain <p> without links must behave
+        exactly as before (flat text replacement)."""
+        xhtml = etree.XML(rb"""<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+    <head><title>Test</title></head>
+    <body>
+        <p id="para1">Hello world.</p>
+    </body>
+</html>""")
+        p = xhtml.find('.//x:p', namespaces=ns)
+        element = PageElement(p, 'p1')
+        element.position = 'only'
+        element.set_placeholder(Base.placeholder)
+        element.set_remove_pattern(None)
+        element.set_reserve_pattern(None)
+        element.get_content()
+        element.add_translation('Ciao mondo.')
+
+        new_p = xhtml.find('.//x:p', namespaces=ns)
+        self.assertIsNotNone(new_p)
+        # id is preserved on the translated element in only mode.
+        self.assertEqual('para1', new_p.get('id'))
+        self.assertEqual('Ciao mondo.', new_p.text)
+        # No child elements (plain paragraph has no structural links).
+        self.assertEqual(0, len(list(new_p)))
+
     def test_add_translation_table(self):
         pass
 

--- a/tests/lib/test_element.py
+++ b/tests/lib/test_element.py
@@ -836,6 +836,43 @@ epub:type="pagebreak"/>b</code></p></body>
         # No child elements (plain paragraph has no structural links).
         self.assertEqual(0, len(list(new_p)))
 
+    def test_add_translation_only_link_with_tail_no_duplication(self):
+        """Regression test for the tail-duplication bug: when a structural
+        link element has a tail (text after the closing tag of the child),
+        e.g. <li><a href="...">Chapter One</a>: The Wrong Door</li>,
+        the translated output must NOT append the original tail text.
+        """
+        xhtml = etree.XML(rb"""<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+    <head><title>Test</title></head>
+    <body>
+        <ul>
+            <li><a href="ch1.xhtml">Chapter One</a>: The Wrong Door</li>
+        </ul>
+    </body>
+</html>""")
+        li = xhtml.find('.//x:li', namespaces=ns)
+        element = PageElement(li, 'p1')
+        element.position = 'only'
+        element.set_placeholder(Base.placeholder)
+        element.set_remove_pattern(None)
+        element.set_reserve_pattern(None)
+        element.get_content()
+        element.add_translation('Capitolo Uno: La porta sbagliata')
+
+        new_li = xhtml.find('.//x:li', namespaces=ns)
+        self.assertIsNotNone(new_li)
+
+        a = xhtml.find('.//x:a', namespaces=ns)
+        self.assertIsNotNone(a)
+        self.assertEqual('ch1.xhtml', a.get('href'))
+
+        full_text = ''.join(new_li.itertext())
+        self.assertNotIn('The Wrong Door', full_text,
+                         'Original tail must not appear in translated output.')
+        self.assertIn('Capitolo', full_text)
+
     def test_add_translation_table(self):
         pass
 

--- a/tests/lib/test_novel.py
+++ b/tests/lib/test_novel.py
@@ -1,0 +1,890 @@
+import json
+import unittest
+from unittest.mock import Mock, patch, call
+
+from ...lib.cache import Paragraph
+from ...lib.exception import TranslationCanceled, TranslationFailed
+from ...lib.novel import (
+    Chapter, ChapterBuilder, TokenBudget, ContextManager, NovelTranslator,
+    tag_paragraphs, parse_tagged_response, _extract_json_object,
+    _extract_entities_fallback,
+    novel_cache_id, _href_to_page_id,
+    INFO_NOVEL_SUMMARIES, INFO_NOVEL_GLOSSARY, INFO_NOVEL_PROGRESS,
+    INFO_NOVEL_MODE)
+
+
+module_name = 'calibre_plugins.ebook_translator.lib.novel'
+
+
+def make_paragraph(pid, text, page='p1', ignored=False):
+    """Build a Paragraph suitable for novel-mode tests."""
+    return Paragraph(
+        pid, 'md5-%s' % pid, text, text, ignored=ignored, page=page)
+
+
+class MockTocNode:
+    """Mimic calibre.ebooks.oeb.base.TOC nodes just enough for the tests."""
+
+    def __init__(self, title, href, children=None):
+        self.title = title
+        self.href = href
+        self.nodes = list(children or [])
+
+
+class MockManifestItem:
+    def __init__(self, item_id, href):
+        self.id = item_id
+        self.href = href
+
+
+# ---------------------------------------------------------------------------
+# _href_to_page_id
+# ---------------------------------------------------------------------------
+
+
+class TestHrefToPageId(unittest.TestCase):
+    def setUp(self):
+        self.items = [
+            MockManifestItem('a', 'OEBPS/ch1.xhtml'),
+            MockManifestItem('b', 'OEBPS/ch2.xhtml'),
+            MockManifestItem('c', 'OEBPS/ch3.xhtml'),
+        ]
+
+    def test_exact_match(self):
+        self.assertEqual('a', _href_to_page_id(
+            'OEBPS/ch1.xhtml', self.items))
+
+    def test_fragment_stripped(self):
+        self.assertEqual('b', _href_to_page_id(
+            'OEBPS/ch2.xhtml#section-3', self.items))
+
+    def test_basename_fallback(self):
+        self.assertEqual('c', _href_to_page_id('ch3.xhtml', self.items))
+
+    def test_empty_href(self):
+        self.assertIsNone(_href_to_page_id('', self.items))
+        self.assertIsNone(_href_to_page_id(None, self.items))
+
+    def test_unknown(self):
+        self.assertIsNone(_href_to_page_id('unknown.xhtml', self.items))
+
+
+# ---------------------------------------------------------------------------
+# ChapterBuilder
+# ---------------------------------------------------------------------------
+
+
+class TestChapterBuilder(unittest.TestCase):
+    def setUp(self):
+        # Three xhtml pages, spine order = a, b, c.
+        self.pages = ['a', 'b', 'c']
+        self.items = [
+            MockManifestItem('a', 'OEBPS/ch1.xhtml'),
+            MockManifestItem('b', 'OEBPS/ch2.xhtml'),
+            MockManifestItem('c', 'OEBPS/ch3.xhtml'),
+        ]
+        self.paragraphs = [
+            make_paragraph(0, 'Alpha 1', page='a'),
+            make_paragraph(1, 'Alpha 2', page='a'),
+            make_paragraph(2, 'Beta 1', page='b'),
+            make_paragraph(3, 'Beta 2', page='b'),
+            make_paragraph(4, 'Gamma 1', page='c'),
+            # Aux metadata paragraphs, should be filtered out.
+            make_paragraph(5, 'Book title', page='content.opf'),
+            make_paragraph(6, 'TOC title', page='toc.ncx'),
+        ]
+
+    def test_toc_level_1(self):
+        toc = [
+            MockTocNode('Chapter One', 'OEBPS/ch1.xhtml'),
+            MockTocNode('Chapter Two', 'OEBPS/ch2.xhtml'),
+            MockTocNode('Chapter Three', 'OEBPS/ch3.xhtml'),
+        ]
+        chapters = ChapterBuilder(
+            self.pages, toc, self.items, self.paragraphs).build()
+        self.assertEqual(3, len(chapters))
+        self.assertEqual([1, 2, 3], [c.index for c in chapters])
+        self.assertEqual(
+            ['Chapter One', 'Chapter Two', 'Chapter Three'],
+            [c.title for c in chapters])
+        self.assertEqual(2, len(chapters[0].paragraphs))
+        self.assertEqual(2, len(chapters[1].paragraphs))
+        self.assertEqual(1, len(chapters[2].paragraphs))
+        # Aux paragraphs must not leak into chapters.
+        for c in chapters:
+            for p in c.paragraphs:
+                self.assertNotIn(p.page, ChapterBuilder.AUX_PAGES)
+
+    def test_toc_level_1_only_ignores_nested(self):
+        # Only the top-level nodes should define chapter boundaries; a
+        # nested subnode inside "Chapter One" must not split the chapter.
+        toc = [
+            MockTocNode('Chapter One', 'OEBPS/ch1.xhtml', [
+                MockTocNode('Section 1.1', 'OEBPS/ch2.xhtml')]),
+            MockTocNode('Chapter Two', 'OEBPS/ch3.xhtml'),
+        ]
+        chapters = ChapterBuilder(
+            self.pages, toc, self.items, self.paragraphs).build()
+        self.assertEqual(2, len(chapters))
+        # Chapter One should now include pages a and b.
+        self.assertEqual(['a', 'b'], chapters[0].page_ids)
+        self.assertEqual(['c'], chapters[1].page_ids)
+
+    def test_fallback_to_files_when_toc_empty(self):
+        chapters = ChapterBuilder(
+            self.pages, [], self.items, self.paragraphs).build()
+        self.assertEqual(3, len(chapters))
+        # Titles derive from first paragraph text.
+        self.assertEqual('Alpha 1', chapters[0].title)
+        self.assertEqual('Beta 1', chapters[1].title)
+        self.assertEqual('Gamma 1', chapters[2].title)
+
+    def test_fallback_when_toc_has_single_node(self):
+        toc = [MockTocNode('Only', 'OEBPS/ch1.xhtml')]
+        chapters = ChapterBuilder(
+            self.pages, toc, self.items, self.paragraphs).build()
+        # Falls back to xhtml file mode -> 3 chapters, not 1.
+        self.assertEqual(3, len(chapters))
+
+    def test_page_before_first_boundary_goes_to_chapter_1(self):
+        # TOC starts at ch2 but page 'a' exists in the spine.
+        toc = [
+            MockTocNode('Chapter Two', 'OEBPS/ch2.xhtml'),
+            MockTocNode('Chapter Three', 'OEBPS/ch3.xhtml'),
+        ]
+        chapters = ChapterBuilder(
+            self.pages, toc, self.items, self.paragraphs).build()
+        self.assertEqual(2, len(chapters))
+        self.assertIn('a', chapters[0].page_ids)
+        self.assertIn('b', chapters[0].page_ids)
+        self.assertIn('c', chapters[1].page_ids)
+
+    def test_toc_with_bad_href_is_skipped(self):
+        toc = [
+            MockTocNode('Chapter One', 'OEBPS/ch1.xhtml'),
+            MockTocNode('Broken', 'does_not_exist.xhtml'),
+            MockTocNode('Chapter Two', 'OEBPS/ch2.xhtml'),
+        ]
+        chapters = ChapterBuilder(
+            self.pages, toc, self.items, self.paragraphs).build()
+        # Broken href yields 2 usable boundaries, not 3.
+        self.assertEqual(2, len(chapters))
+
+    def test_aux_paragraphs_collected_separately(self):
+        builder = ChapterBuilder(
+            self.pages, [], self.items, self.paragraphs)
+        self.assertEqual(2, len(builder.aux_paragraphs))
+        pages = {p.page for p in builder.aux_paragraphs}
+        self.assertEqual({'content.opf', 'toc.ncx'}, pages)
+
+    def test_ignored_paragraphs_kept_but_not_counted(self):
+        paragraphs = list(self.paragraphs)
+        paragraphs[0].ignored = True  # First 'a' paragraph is ignored.
+        chapters = ChapterBuilder(
+            self.pages, [], self.items, paragraphs).build()
+        # It still travels through the pipeline so DOM re-assembly can run.
+        self.assertEqual(2, len(chapters[0].paragraphs))
+        # But translatable count reflects the ignored flag.
+        self.assertEqual(1, len(chapters[0].translatable_paragraphs()))
+
+    def test_empty_spine(self):
+        chapters = ChapterBuilder([], [], [], []).build()
+        self.assertEqual([], chapters)
+
+    def test_char_count(self):
+        chapter = Chapter(1, 't', ['a'], [
+            make_paragraph(0, 'hello'),
+            make_paragraph(1, 'world!', ignored=True),
+            make_paragraph(2, ''),
+        ])
+        # Only non-ignored paragraphs contribute.
+        self.assertEqual(len('hello') + 0, chapter.char_count)
+
+
+# ---------------------------------------------------------------------------
+# TokenBudget
+# ---------------------------------------------------------------------------
+
+
+class TestTokenBudget(unittest.TestCase):
+    def test_estimate_latin(self):
+        budget = TokenBudget()
+        # ~4 chars/token on latin text.
+        self.assertGreater(budget.estimate('hello world!'), 0)
+        self.assertLess(budget.estimate('hello world!'), 10)
+
+    def test_estimate_cjk(self):
+        budget = TokenBudget()
+        # 4 CJK characters -> ~2 tokens with ratio_cjk=2.
+        cjk_text = '你好世界'
+        self.assertGreaterEqual(budget.estimate(cjk_text), 2)
+
+    def test_estimate_empty(self):
+        self.assertEqual(0, TokenBudget().estimate(''))
+        self.assertEqual(0, TokenBudget().estimate(None))
+
+    def test_budget_minimum(self):
+        # Very small budgets are clamped to at least 100.
+        budget = TokenBudget(budget=10)
+        self.assertEqual(100, budget.budget)
+
+    def test_chunk_single_fit(self):
+        paragraphs = [
+            make_paragraph(0, 'short one'),
+            make_paragraph(1, 'short two'),
+            make_paragraph(2, 'short three'),
+        ]
+        budget = TokenBudget(budget=8000)
+        chunks = budget.chunk(paragraphs, reserved=0)
+        self.assertEqual(1, len(chunks))
+        self.assertEqual(3, len(chunks[0]))
+
+    def test_chunk_splits_when_needed(self):
+        # A tiny budget will force multiple chunks.
+        paragraphs = [
+            make_paragraph(0, 'x' * 400),
+            make_paragraph(1, 'y' * 400),
+            make_paragraph(2, 'z' * 400),
+        ]
+        # 400 chars / 4 ~= 100 tokens per paragraph.
+        budget = TokenBudget(budget=200)
+        chunks = budget.chunk(paragraphs, reserved=0)
+        self.assertGreater(len(chunks), 1)
+        # Total paragraphs preserved.
+        total = sum(len(c) for c in chunks)
+        self.assertEqual(3, total)
+
+    def test_chunk_never_splits_paragraph(self):
+        paragraphs = [make_paragraph(0, 'x' * 100000)]  # ~25k tokens
+        budget = TokenBudget(budget=200)
+        chunks = budget.chunk(paragraphs, reserved=0)
+        self.assertEqual(1, len(chunks))
+        self.assertEqual(1, len(chunks[0]))
+
+    def test_chunk_reserves_headroom(self):
+        paragraphs = [make_paragraph(i, 'x' * 400) for i in range(10)]
+        # 8000 budget, reserved 7500 -> only 500 tokens available.
+        # Each paragraph ~100 tokens -> at most ~5 per chunk.
+        budget = TokenBudget(budget=8000)
+        chunks = budget.chunk(paragraphs, reserved=7500)
+        self.assertGreater(len(chunks), 1)
+        for chunk in chunks:
+            self.assertLessEqual(len(chunk), 5)
+
+    def test_chunk_carries_ignored_paragraphs(self):
+        paragraphs = [
+            make_paragraph(0, 'text 1'),
+            make_paragraph(1, '', ignored=True),
+            make_paragraph(2, 'text 2'),
+        ]
+        chunks = TokenBudget(budget=8000).chunk(paragraphs, reserved=0)
+        self.assertEqual(1, len(chunks))
+        # All paragraphs (including ignored) are still present.
+        self.assertEqual(3, len(chunks[0]))
+
+
+# ---------------------------------------------------------------------------
+# ContextManager
+# ---------------------------------------------------------------------------
+
+
+class TestContextManager(unittest.TestCase):
+    def setUp(self):
+        self.cache = Mock()
+        self.cache.get_info.return_value = None
+
+    def test_load_empty(self):
+        ctx = ContextManager(self.cache).load()
+        self.assertEqual([], ctx.get_summaries())
+        self.assertEqual({}, ctx.get_glossary())
+        self.assertEqual(0, ctx.get_progress())
+        # load() also marks the cache as novel-mode.
+        self.cache.set_info.assert_any_call(INFO_NOVEL_MODE, '1')
+
+    def test_load_existing(self):
+        summaries = [{'chapter': 1, 'title': 'a', 'summary': 'ok'}]
+        glossary = {'Frodo': {
+            'translation': 'Frodo', 'type': 'character', 'notes': 'hobbit'}}
+        self.cache.get_info.side_effect = lambda key: {
+            INFO_NOVEL_SUMMARIES: json.dumps(summaries),
+            INFO_NOVEL_GLOSSARY: json.dumps(glossary),
+            INFO_NOVEL_PROGRESS: '1',
+        }.get(key)
+        ctx = ContextManager(self.cache).load()
+        self.assertEqual(summaries, ctx.get_summaries())
+        self.assertEqual(glossary, ctx.get_glossary())
+        self.assertEqual(1, ctx.get_progress())
+
+    def test_load_handles_corrupted_json(self):
+        self.cache.get_info.side_effect = lambda key: {
+            INFO_NOVEL_SUMMARIES: 'not json',
+            INFO_NOVEL_GLOSSARY: '[not a dict]',
+            INFO_NOVEL_PROGRESS: 'garbage',
+        }.get(key)
+        ctx = ContextManager(self.cache).load()
+        self.assertEqual([], ctx.get_summaries())
+        self.assertEqual({}, ctx.get_glossary())
+        self.assertEqual(0, ctx.get_progress())
+
+    def test_append_chapter(self):
+        ctx = ContextManager(self.cache).load()
+        ctx.append_chapter(1, 'The Ring', 'Frodo gets the ring.', [
+            {'source': 'Frodo', 'translation': 'Frodo',
+             'type': 'character', 'notes': 'hobbit'},
+            {'source': 'The Shire', 'translation': 'La Contea',
+             'type': 'place'},
+        ])
+        summaries = ctx.get_summaries()
+        self.assertEqual(1, len(summaries))
+        self.assertEqual('Frodo gets the ring.', summaries[0]['summary'])
+        glossary = ctx.get_glossary()
+        self.assertIn('Frodo', glossary)
+        self.assertEqual('La Contea', glossary['The Shire']['translation'])
+        self.assertEqual(1, ctx.get_progress())
+        # Persistence: three set_info calls (summaries, glossary, progress).
+        keys = [c.args[0] for c in self.cache.set_info.call_args_list]
+        self.assertIn(INFO_NOVEL_SUMMARIES, keys)
+        self.assertIn(INFO_NOVEL_GLOSSARY, keys)
+        self.assertIn(INFO_NOVEL_PROGRESS, keys)
+
+    def test_append_chapter_ignores_malformed_entities(self):
+        ctx = ContextManager(self.cache).load()
+        ctx.append_chapter(1, 't', 's', [
+            {'source': 'Ok', 'translation': 'Ok'},
+            {'source': '', 'translation': 'nope'},      # empty source
+            {'source': 'X', 'translation': ''},         # empty translation
+            'not a dict',
+            {'source': 'Y'},                             # missing translation
+        ])
+        self.assertEqual(['Ok'], list(ctx.get_glossary().keys()))
+
+    def test_glossary_cap_fifo(self):
+        ctx = ContextManager(self.cache, glossary_max_entries=3).load()
+        ctx.append_chapter(1, 't', 's', [
+            {'source': 'A', 'translation': 'A'},
+            {'source': 'B', 'translation': 'B'},
+            {'source': 'C', 'translation': 'C'},
+        ])
+        self.assertEqual(3, len(ctx.get_glossary()))
+        ctx.append_chapter(2, 't', 's', [
+            {'source': 'D', 'translation': 'D'},
+        ])
+        keys = list(ctx.get_glossary().keys())
+        self.assertEqual(3, len(keys))
+        self.assertNotIn('A', keys)  # Oldest dropped.
+        self.assertIn('D', keys)
+
+    def test_progress_never_decreases(self):
+        ctx = ContextManager(self.cache).load()
+        ctx.append_chapter(3, 't', 's')
+        self.assertEqual(3, ctx.get_progress())
+        ctx.append_chapter(2, 't', 's')  # Retro-append should not lower.
+        self.assertEqual(3, ctx.get_progress())
+
+    def test_context_text_basic(self):
+        ctx = ContextManager(self.cache).load()
+        ctx.append_chapter(1, 'Prologue', 'Something happens.', [
+            {'source': 'Bilbo', 'translation': 'Bilbo',
+             'type': 'character'},
+        ])
+        text = ctx.context_text(budget_tokens=2000)
+        self.assertIn('Prologue', text)
+        self.assertIn('Something happens.', text)
+        self.assertIn('Bilbo', text)
+
+    def test_context_text_truncation(self):
+        ctx = ContextManager(self.cache).load()
+        # Fill with many long summaries; small budget forces trimming.
+        for i in range(10):
+            ctx.append_chapter(
+                i + 1, 'T%d' % i, 'x' * 500,
+                [{'source': 'K%d' % i, 'translation': 'V%d' % i}])
+        # Budget of 100 tokens ~= 400 chars.
+        text = ctx.context_text(budget_tokens=100)
+        # It should never be empty and always contain the header labels.
+        self.assertTrue(text)
+
+    def test_replace_glossary(self):
+        ctx = ContextManager(self.cache).load()
+        ctx.append_chapter(1, 't', 's', [
+            {'source': 'A', 'translation': 'A'},
+        ])
+        ctx.replace_glossary({
+            'B': {'translation': 'B', 'type': 'character'},
+            'Bad': {'translation': ''},  # dropped: missing translation
+            'Weird': 'not a dict',        # dropped: wrong type
+        })
+        self.assertEqual({'B'}, set(ctx.get_glossary().keys()))
+
+    def test_reset(self):
+        ctx = ContextManager(self.cache).load()
+        ctx.append_chapter(2, 't', 's', [
+            {'source': 'A', 'translation': 'A'}])
+        ctx.reset()
+        self.assertEqual([], ctx.get_summaries())
+        self.assertEqual({}, ctx.get_glossary())
+        self.assertEqual(0, ctx.get_progress())
+
+
+# ---------------------------------------------------------------------------
+# tag_paragraphs / parse_tagged_response
+# ---------------------------------------------------------------------------
+
+
+class TestTagging(unittest.TestCase):
+    def test_tag_paragraphs_basic(self):
+        paragraphs = [
+            make_paragraph(0, 'First.'),
+            make_paragraph(1, 'Second.'),
+            make_paragraph(2, 'Third.'),
+        ]
+        tagged, indices = tag_paragraphs(paragraphs)
+        self.assertEqual([1, 2, 3], indices)
+        self.assertIn('<P1>First.</P1>', tagged)
+        self.assertIn('<P2>Second.</P2>', tagged)
+        self.assertIn('<P3>Third.</P3>', tagged)
+
+    def test_tag_paragraphs_skips_ignored(self):
+        paragraphs = [
+            make_paragraph(0, 'A'),
+            make_paragraph(1, 'B', ignored=True),
+            make_paragraph(2, 'C'),
+        ]
+        tagged, indices = tag_paragraphs(paragraphs)
+        # Indices count the *paragraphs list* position, not translated count.
+        self.assertEqual([1, 3], indices)
+        self.assertIn('<P1>A</P1>', tagged)
+        self.assertIn('<P3>C</P3>', tagged)
+        self.assertNotIn('<P2>', tagged)
+
+    def test_parse_tagged_response(self):
+        response = (
+            "Sure, here is the translation:\n"
+            "<P1>Primo.</P1>\n"
+            "<P2>Secondo.</P2>\n"
+            "<P3>Terzo.</P3>\nEnd of translation.")
+        parsed = parse_tagged_response(response, [1, 2, 3])
+        self.assertEqual({1: 'Primo.', 2: 'Secondo.', 3: 'Terzo.'}, parsed)
+
+    def test_parse_tagged_response_multiline(self):
+        response = (
+            "<P1>Line one.\nLine two.</P1>\n"
+            "<P2>Alone.</P2>")
+        parsed = parse_tagged_response(response, [1, 2])
+        self.assertEqual(2, len(parsed))
+        self.assertIn('Line one.', parsed[1])
+        self.assertIn('Line two.', parsed[1])
+
+    def test_parse_tagged_response_missing(self):
+        response = "<P1>Only one.</P1>"
+        parsed = parse_tagged_response(response, [1, 2, 3])
+        self.assertEqual({1: 'Only one.'}, parsed)
+
+    def test_parse_tagged_response_ignores_hallucinated_tags(self):
+        response = "<P1>Real.</P1><P5>Hallucinated.</P5>"
+        parsed = parse_tagged_response(response, [1, 2])
+        # Tag 5 was not expected; ignored.
+        self.assertEqual({1: 'Real.'}, parsed)
+
+    def test_parse_tagged_response_empty(self):
+        self.assertEqual({}, parse_tagged_response('', [1]))
+        self.assertEqual({}, parse_tagged_response(None, [1]))
+
+
+# ---------------------------------------------------------------------------
+# _extract_json_object
+# ---------------------------------------------------------------------------
+
+
+class TestExtractJson(unittest.TestCase):
+    def test_clean_json(self):
+        self.assertEqual(
+            {'a': 1}, _extract_json_object('{"a": 1}'))
+
+    def test_with_prose_prefix(self):
+        self.assertEqual(
+            {'entities': []},
+            _extract_json_object('Here is the JSON:\n{"entities": []}'))
+
+    def test_with_code_fence(self):
+        self.assertEqual(
+            {'x': 'y'},
+            _extract_json_object('```json\n{"x": "y"}\n```'))
+
+    def test_ignores_braces_in_strings(self):
+        self.assertEqual(
+            {'text': 'this { is not } a brace'},
+            _extract_json_object('{"text": "this { is not } a brace"}'))
+
+    def test_returns_none_when_invalid(self):
+        self.assertIsNone(_extract_json_object('no json here'))
+        self.assertIsNone(_extract_json_object(''))
+        self.assertIsNone(_extract_json_object(None))
+        self.assertIsNone(_extract_json_object('{"broken":'))
+
+
+class TestExtractEntitiesFallback(unittest.TestCase):
+    def test_arrow_syntax(self):
+        text = (
+            'Here are some entities:\n'
+            '"Aslan" -> "Aslan" (character): the lion king\n'
+            '"Narnia" -> "Narnia" (place)\n'
+            'End of list.')
+        entities = _extract_entities_fallback(text)
+        sources = [e['source'] for e in entities]
+        self.assertIn('Aslan', sources)
+        self.assertIn('Narnia', sources)
+
+    def test_double_arrow_syntax(self):
+        text = 'Aslan => Aslan (character) - the lion'
+        entities = _extract_entities_fallback(text)
+        self.assertTrue(
+            any(e['source'] == 'Aslan' for e in entities))
+
+    def test_unicode_arrow(self):
+        text = '"Frodo" → "Frodo" (character): the hobbit'
+        entities = _extract_entities_fallback(text)
+        self.assertTrue(
+            any(e['source'] == 'Frodo' for e in entities))
+
+    def test_skips_prose_lines(self):
+        text = (
+            'This sentence has many words but is not an entity mapping.\n'
+            'Here are the entities I extracted from the chapter:')
+        entities = _extract_entities_fallback(text)
+        # No entity mapping in prose (no ``->`` separator).
+        self.assertEqual([], entities)
+
+    def test_empty_returns_empty(self):
+        self.assertEqual([], _extract_entities_fallback(''))
+        self.assertEqual([], _extract_entities_fallback(None))
+
+    def test_dedup_by_source(self):
+        text = (
+            '"Aslan" -> "Aslan" (character): king\n'
+            '"Aslan" -> "Aslan" (character): duplicate line')
+        entities = _extract_entities_fallback(text)
+        self.assertEqual(
+            1, sum(1 for e in entities if e['source'] == 'Aslan'))
+
+
+# ---------------------------------------------------------------------------
+# novel_cache_id
+# ---------------------------------------------------------------------------
+
+
+class TestNovelCacheId(unittest.TestCase):
+    def test_deterministic(self):
+        a = novel_cache_id('/b.epub', 'ChatGPT', 'Italian', '')
+        b = novel_cache_id('/b.epub', 'ChatGPT', 'Italian', '')
+        self.assertEqual(a, b)
+
+    def test_differs_from_classic(self):
+        from ...lib.utils import uid
+        classic = uid('/b.epub' + 'ChatGPT' + 'Italian' + '1800' + '')
+        novel = novel_cache_id('/b.epub', 'ChatGPT', 'Italian', '')
+        self.assertNotEqual(classic, novel)
+
+    def test_encoding_included(self):
+        a = novel_cache_id('/b.epub', 'ChatGPT', 'Italian', '')
+        b = novel_cache_id('/b.epub', 'ChatGPT', 'Italian', 'gbk')
+        self.assertNotEqual(a, b)
+
+
+# ---------------------------------------------------------------------------
+# NovelTranslator
+# ---------------------------------------------------------------------------
+
+
+class FakeEngine:
+    """Minimal engine stub compatible with NovelTranslator expectations."""
+
+    name = 'FakeEngine'
+    request_attempt = 2
+    source_lang = 'English'
+    target_lang = 'Italian'
+
+    def __init__(self, translate_side_effect=None):
+        self.prompt = 'original prompt'
+        self.translate_calls = []
+        self._translate_side_effect = translate_side_effect
+
+    def override_prompt(self, prompt):
+        self._stash = self.prompt
+        self.prompt = prompt
+
+    def restore_prompt(self):
+        if hasattr(self, '_stash'):
+            self.prompt = self._stash
+
+    def get_target_lang(self):
+        return self.target_lang
+
+    def translate(self, text):
+        self.translate_calls.append({
+            'prompt': self.prompt, 'text': text})
+        if self._translate_side_effect is not None:
+            value = self._translate_side_effect(text, self.prompt)
+            if isinstance(value, Exception):
+                raise value
+            return value
+        return text
+
+
+class TestNovelTranslator(unittest.TestCase):
+    def setUp(self):
+        self.cache = Mock()
+        self.cache.get_info.return_value = None
+        self.ctx = ContextManager(self.cache).load()
+        # Reset mock so we can inspect only calls made during the test proper.
+        self.cache.reset_mock()
+
+        self.paragraphs = [
+            make_paragraph(0, 'Alpha 1', page='a'),
+            make_paragraph(1, 'Alpha 2', page='a'),
+            make_paragraph(2, 'Beta 1', page='b'),
+        ]
+        self.chapters = [
+            Chapter(1, 'Chapter One', ['a'], self.paragraphs[:2]),
+            Chapter(2, 'Chapter Two', ['b'], self.paragraphs[2:]),
+        ]
+
+    def _make_translator(self, engine, config=None):
+        # Disable the short-chapter guard by default so tests can use tiny
+        # synthetic paragraphs without their summary/glossary calls being
+        # short-circuited by ``novel_min_chars_for_context``.
+        base_config = {'novel_min_chars_for_context': 0}
+        if config:
+            base_config.update(config)
+        translator = NovelTranslator(
+            engine, self.chapters, self.ctx, self.cache,
+            config=base_config)
+        translator.set_logging(Mock())
+        translator.set_progress(Mock())
+        return translator
+
+    def test_run_translates_all_chapters(self):
+        def side_effect(text, prompt):
+            # Translation call: response contains the same tags.
+            if '<P1>' in text or '<P2>' in text or '<P3>' in text:
+                # Echo back all tags found in the user text.
+                import re
+                result = []
+                for m in re.finditer(r'<P(\d+)>(.*?)</P\1>',
+                                     text, re.DOTALL):
+                    result.append('<P%s>%s (IT)</P%s>' % (
+                        m.group(1), m.group(2), m.group(1)))
+                return '\n'.join(result)
+            # Summary and glossary calls: return trivial values.
+            if 'Summarize' in prompt or 'summar' in prompt.lower():
+                return 'Summary text.'
+            if 'JSON' in prompt or 'entities' in prompt.lower():
+                return '{"entities": []}'
+            # Fallback (used e.g. by summary user-side prompt).
+            if 'summary' in text.lower():
+                return 'Summary text.'
+            return '{"entities": []}'
+        engine = FakeEngine(translate_side_effect=side_effect)
+        translator = self._make_translator(engine)
+        count = translator.run()
+        self.assertEqual(2, count)
+        # Both chapters were persisted.
+        self.assertEqual(2, self.ctx.get_progress())
+        # All non-ignored paragraphs got translated.
+        for p in self.paragraphs:
+            self.assertIsNotNone(p.translation)
+            self.assertIn('(IT)', p.translation)
+            self.assertEqual('FakeEngine', p.engine_name)
+            self.assertEqual('Italian', p.target_lang)
+
+    def test_run_resumes_from_progress(self):
+        # Simulate a previous run that completed chapter 1.
+        self.ctx.progress = 1
+        collected = []
+
+        def side_effect(text, prompt):
+            collected.append(text[:20])
+            if '<P' in text:
+                import re
+                return '\n'.join(
+                    '<P%s>%s (IT)</P%s>' % (m.group(1), m.group(2),
+                                             m.group(1))
+                    for m in re.finditer(r'<P(\d+)>(.*?)</P\1>',
+                                         text, re.DOTALL))
+            return '{"entities": []}'
+        engine = FakeEngine(translate_side_effect=side_effect)
+        translator = self._make_translator(engine)
+        count = translator.run()
+        self.assertEqual(1, count)
+        # Only chapter 2 paragraph should be translated in this run.
+        self.assertIsNone(self.paragraphs[0].translation)
+        self.assertIsNone(self.paragraphs[1].translation)
+        self.assertIsNotNone(self.paragraphs[2].translation)
+
+    def test_cancel_stops_run(self):
+        engine = FakeEngine()
+        translator = self._make_translator(engine)
+        translator.set_cancel_request(lambda: True)
+        with self.assertRaises(TranslationCanceled):
+            translator.run()
+
+    def test_missing_tags_are_logged(self):
+        # Engine that returns only tag 1 -> alignment retries kick in but
+        # still miss tag 2.
+        def side_effect(text, prompt):
+            if '<P' in text:
+                return '<P1>Only first.</P1>'
+            return '{"entities": []}'
+        engine = FakeEngine(translate_side_effect=side_effect)
+        translator = self._make_translator(engine)
+        log = Mock()
+        translator.set_logging(log)
+        translator.run()
+        # The paragraph that was translated is stored, the missing one is
+        # left as None but progress still advances (soft failure).
+        self.assertEqual('Only first.', self.paragraphs[0].translation)
+        # Missing-tag warning was logged at some point.
+        warning_seen = any(
+            'missing' in (c.args[0] if c.args else '').lower()
+            for c in log.call_args_list)
+        self.assertTrue(warning_seen)
+
+    def test_summary_and_glossary_persisted(self):
+        def side_effect(text, prompt):
+            if '<P' in text and 'JSON' not in prompt \
+                    and 'entities' not in prompt.lower():
+                import re
+                return '\n'.join(
+                    '<P%s>%s (IT)</P%s>' % (m.group(1), m.group(2),
+                                             m.group(1))
+                    for m in re.finditer(r'<P(\d+)>(.*?)</P\1>',
+                                         text, re.DOTALL))
+            if 'JSON' in prompt or 'entities' in prompt.lower():
+                return ('Here is JSON: {"entities": ['
+                        '{"source": "Alpha", "translation": "Alfa", '
+                        '"type": "character"}]}')
+            # Summary path.
+            return 'This chapter introduces Alpha.'
+        engine = FakeEngine(translate_side_effect=side_effect)
+        translator = self._make_translator(engine)
+        translator.run()
+        summaries = self.ctx.get_summaries()
+        self.assertEqual(2, len(summaries))
+        self.assertIn('Alpha', summaries[0]['summary'])
+        glossary = self.ctx.get_glossary()
+        self.assertIn('Alpha', glossary)
+        self.assertEqual('Alfa', glossary['Alpha']['translation'])
+
+    def test_no_translatable_content_skips_chapter(self):
+        # Chapter 1 contains only an ignored paragraph.
+        self.chapters[0] = Chapter(1, 'Empty', ['a'], [
+            make_paragraph(0, '', page='a', ignored=True)])
+
+        def side_effect(text, prompt):
+            if '<P' in text:
+                import re
+                return '\n'.join(
+                    '<P%s>%s (IT)</P%s>' % (m.group(1), m.group(2),
+                                             m.group(1))
+                    for m in re.finditer(r'<P(\d+)>(.*?)</P\1>',
+                                         text, re.DOTALL))
+            return '{"entities": []}'
+        engine = FakeEngine(translate_side_effect=side_effect)
+        translator = self._make_translator(engine)
+        translator.run()
+        # Progress still advances past chapter 1.
+        self.assertEqual(2, self.ctx.get_progress())
+
+    def test_short_chapters_skip_context_calls(self):
+        # With the default guard, tiny chapters ("Alpha 1", "Alpha 2", ...)
+        # must be translated but must NOT trigger summary / glossary calls.
+        tracker = {'summary': 0, 'glossary': 0}
+
+        def side_effect(text, prompt):
+            if '<P' in text and 'JSON' not in prompt \
+                    and 'entities' not in prompt.lower():
+                import re
+                return '\n'.join(
+                    '<P%s>%s (IT)</P%s>' % (m.group(1), m.group(2),
+                                             m.group(1))
+                    for m in re.finditer(r'<P(\d+)>(.*?)</P\1>',
+                                         text, re.DOTALL))
+            if 'JSON' in prompt or 'entities' in prompt.lower():
+                tracker['glossary'] += 1
+                return '{"entities": []}'
+            # Assume any other call is the summary request.
+            tracker['summary'] += 1
+            return 'Summary text.'
+
+        engine = FakeEngine(translate_side_effect=side_effect)
+        # Explicit threshold well above the tiny sample paragraphs.
+        translator = self._make_translator(
+            engine, config={'novel_min_chars_for_context': 500})
+        translator.run()
+        # Both chapters are shorter than 500 chars once translated: no
+        # summary / glossary calls should be made.
+        self.assertEqual(0, tracker['summary'])
+        self.assertEqual(0, tracker['glossary'])
+        # But paragraphs must still be translated.
+        for p in self.paragraphs:
+            self.assertIsNotNone(p.translation)
+
+    def test_glossary_fallback_from_line_based(self):
+        # LLM returns a non-JSON list; the fallback parser should
+        # recover some entries.
+        long_text = ' '.join(['Alpha'] * 200)  # push chapter over threshold
+        self.paragraphs = [
+            make_paragraph(0, long_text, page='a'),
+            make_paragraph(1, long_text, page='b'),
+        ]
+        self.chapters = [
+            Chapter(1, 'Chapter One', ['a'], self.paragraphs[:1]),
+            Chapter(2, 'Chapter Two', ['b'], self.paragraphs[1:]),
+        ]
+
+        def side_effect(text, prompt):
+            if '<P' in text and 'JSON' not in prompt \
+                    and 'entities' not in prompt.lower():
+                import re
+                return '\n'.join(
+                    '<P%s>%s (IT)</P%s>' % (m.group(1), m.group(2),
+                                             m.group(1))
+                    for m in re.finditer(r'<P(\d+)>(.*?)</P\1>',
+                                         text, re.DOTALL))
+            if 'JSON' in prompt or 'entities' in prompt.lower():
+                # Return plain prose, not JSON.
+                return (
+                    'Here are the entities I found:\n'
+                    '"Alpha" -> "Alfa" (character): main figure\n'
+                    '"Beta" -> "Beta" (place)\n'
+                    'Nothing else notable.')
+            return 'Summary text.'
+
+        engine = FakeEngine(translate_side_effect=side_effect)
+        translator = self._make_translator(engine)
+        translator.run()
+        glossary = self.ctx.get_glossary()
+        # At least one entity should have been recovered via the fallback.
+        self.assertGreater(len(glossary), 0)
+
+    def test_translation_failure_after_retries(self):
+        engine = FakeEngine(
+            translate_side_effect=lambda t, p: Exception('boom'))
+        translator = self._make_translator(engine)
+        with patch(f'{module_name}.time'):
+            with self.assertRaises(TranslationFailed):
+                translator.run()
+
+    @patch(f'{module_name}.time')
+    def test_retry_sleeps_between_attempts(self, mock_time):
+        engine = FakeEngine(
+            translate_side_effect=lambda t, p: Exception('nope'))
+        translator = self._make_translator(engine)
+        # request_attempt=2 -> two attempts, one sleep in between.
+        with self.assertRaises(TranslationFailed):
+            translator._translate_with_retry('sys', 'user', attempts=2)
+        mock_time.sleep.assert_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/lib/test_novel.py
+++ b/tests/lib/test_novel.py
@@ -471,10 +471,11 @@ class TestTokenBudget(unittest.TestCase):
         self.assertEqual(200, len(chunks[0]))
 
     def test_chunk_default_max_paragraphs(self):
-        # Default is deliberately conservative (20) to ensure high tag
-        # compliance on local medium-sized models.
+        # Default is 80: with structured JSON output the model reliably
+        # follows alignment markers at this count, making it the appropriate
+        # default for capable engines (ChatGPT, Gemini, Ollama 0.31+).
         budget = TokenBudget(budget=8000)
-        self.assertEqual(20, budget.max_paragraphs)
+        self.assertEqual(80, budget.max_paragraphs)
 
     def test_chunk_with_stats_reports_reason(self):
         # 70 short paragraphs, generous token budget, cap=60.

--- a/tests/lib/test_novel.py
+++ b/tests/lib/test_novel.py
@@ -84,11 +84,20 @@ class TestChapterBuilder(unittest.TestCase):
             MockManifestItem('c', 'OEBPS/ch3.xhtml'),
         ]
         self.paragraphs = [
-            make_paragraph(0, 'Alpha 1', page='a'),
-            make_paragraph(1, 'Alpha 2', page='a'),
-            make_paragraph(2, 'Beta 1', page='b'),
-            make_paragraph(3, 'Beta 2', page='b'),
-            make_paragraph(4, 'Gamma 1', page='c'),
+            make_paragraph(0, 'Alpha paragraph one with enough text to pass the front-matter filter.',
+                           page='a'),
+            make_paragraph(1, 'Alpha paragraph two with enough text to pass the front-matter filter.',
+                           page='a'),
+            make_paragraph(2, 'Beta paragraph one with enough text to pass the front-matter filter.',
+                           page='b'),
+            make_paragraph(3, 'Beta paragraph two with enough text to pass the front-matter filter.',
+                           page='b'),
+            make_paragraph(
+                4,
+                'Gamma paragraph one: this single paragraph is intentionally long '
+                'so that the front-matter filter (default 100 chars) does not '
+                'exclude the page from chapter content.',
+                page='c'),
             # Aux metadata paragraphs, should be filtered out.
             make_paragraph(5, 'Book title', page='content.opf'),
             make_paragraph(6, 'TOC title', page='toc.ncx'),
@@ -134,10 +143,13 @@ class TestChapterBuilder(unittest.TestCase):
         chapters = ChapterBuilder(
             self.pages, [], self.items, self.paragraphs).build()
         self.assertEqual(3, len(chapters))
-        # Titles derive from first paragraph text.
-        self.assertEqual('Alpha 1', chapters[0].title)
-        self.assertEqual('Beta 1', chapters[1].title)
-        self.assertEqual('Gamma 1', chapters[2].title)
+        # Titles derive from first paragraph text (truncated to 80 chars).
+        self.assertTrue(chapters[0].title.startswith('Alpha paragraph one'),
+                        chapters[0].title)
+        self.assertTrue(chapters[1].title.startswith('Beta paragraph one'),
+                        chapters[1].title)
+        self.assertTrue(chapters[2].title.startswith('Gamma paragraph one'),
+                        chapters[2].title)
 
     def test_fallback_when_toc_has_single_node(self):
         toc = [MockTocNode('Only', 'OEBPS/ch1.xhtml')]
@@ -181,7 +193,8 @@ class TestChapterBuilder(unittest.TestCase):
         paragraphs = list(self.paragraphs)
         paragraphs[0].ignored = True  # First 'a' paragraph is ignored.
         chapters = ChapterBuilder(
-            self.pages, [], self.items, paragraphs).build()
+            self.pages, [], self.items, paragraphs,
+            front_matter_min_chars=0).build()
         # It still travels through the pipeline so DOM re-assembly can run.
         self.assertEqual(2, len(chapters[0].paragraphs))
         # But translatable count reflects the ignored flag.
@@ -199,6 +212,147 @@ class TestChapterBuilder(unittest.TestCase):
         ])
         # Only non-ignored paragraphs contribute.
         self.assertEqual(len('hello') + 0, chapter.char_count)
+
+    # -- toc_level_2 ----------------------------------------------------------
+
+    def _pages_and_items_for_anthology(self):
+        """Return spine/items for a minimal 2-book anthology.
+
+        Structure mirrors a real anthology EPUB:
+          spine: cover_b1, ch1_b1, ch2_b1, cover_b2, ch1_b2
+          TOC level-1: Book1 -> cover_b1, Book2 -> cover_b2
+          TOC level-2: Ch1 -> ch1_b1, Ch2 -> ch2_b1, Ch1b2 -> ch1_b2
+        """
+        pages = ['cover_b1', 'ch1_b1', 'ch2_b1', 'cover_b2', 'ch1_b2']
+        items = [
+            MockManifestItem('cover_b1', 'book1/cover.xhtml'),
+            MockManifestItem('ch1_b1', 'book1/chapter1.xhtml'),
+            MockManifestItem('ch2_b1', 'book1/chapter2.xhtml'),
+            MockManifestItem('cover_b2', 'book2/cover.xhtml'),
+            MockManifestItem('ch1_b2', 'book2/chapter1.xhtml'),
+        ]
+        return pages, items
+
+    def test_toc_level2_splits_anthology_into_narrative_chapters(self):
+        pages, items = self._pages_and_items_for_anthology()
+        # Level-1 TOC nodes each have level-2 children.
+        toc = [
+            MockTocNode('Book One', 'book1/cover.xhtml', [
+                MockTocNode('Chapter One', 'book1/chapter1.xhtml'),
+                MockTocNode('Chapter Two', 'book1/chapter2.xhtml'),
+            ]),
+            MockTocNode('Book Two', 'book2/cover.xhtml', [
+                MockTocNode('Chapter One', 'book2/chapter1.xhtml'),
+            ]),
+        ]
+        paragraphs = [
+            make_paragraph(0, 'x' * 200, page='ch1_b1'),
+            make_paragraph(1, 'x' * 200, page='ch2_b1'),
+            make_paragraph(2, 'x' * 200, page='ch1_b2'),
+            # Cover pages: short text (< 100 chars)
+            make_paragraph(3, 'Book One', page='cover_b1'),
+            make_paragraph(4, 'Book Two', page='cover_b2'),
+        ]
+        builder = ChapterBuilder(
+            pages, toc, items, paragraphs, source='toc_level_2',
+            front_matter_min_chars=0)  # disable front-matter filter here
+        chapters = builder.build()
+        # 3 level-2 chapters: Ch1/B1, Ch2/B1, Ch1/B2
+        self.assertEqual(3, len(chapters))
+        self.assertEqual('Chapter One', chapters[0].title)
+        self.assertEqual('Chapter Two', chapters[1].title)
+        self.assertEqual('Chapter One', chapters[2].title)
+
+    def test_toc_level2_fallback_to_level1_when_no_children(self):
+        """If level-2 has fewer than 2 entries, fall back to level-1."""
+        pages, items = self._pages_and_items_for_anthology()
+        toc = [
+            MockTocNode('Book One', 'book1/cover.xhtml'),  # no children
+            MockTocNode('Book Two', 'book2/cover.xhtml'),  # no children
+        ]
+        paragraphs = [make_paragraph(i, 'text', page=p)
+                      for i, p in enumerate(pages)]
+        builder = ChapterBuilder(
+            pages, toc, items, paragraphs, source='toc_level_2',
+            front_matter_min_chars=0)
+        chapters = builder.build()
+        # Falls back to level-1 -> 2 chapters
+        self.assertEqual(2, len(chapters))
+        self.assertEqual('Book One', chapters[0].title)
+
+    # -- front-matter filter --------------------------------------------------
+
+    def test_front_matter_filter_excludes_short_pages(self):
+        """Pages with very little text are excluded from chapter content."""
+        pages = ['cover', 'ch1', 'ch2']
+        items = [
+            MockManifestItem('cover', 'cover.xhtml'),
+            MockManifestItem('ch1', 'chapter1.xhtml'),
+            MockManifestItem('ch2', 'chapter2.xhtml'),
+        ]
+        toc = [
+            MockTocNode('Ch1', 'chapter1.xhtml'),
+            MockTocNode('Ch2', 'chapter2.xhtml'),
+        ]
+        paragraphs = [
+            # Cover page: 8 chars only (below threshold 100)
+            make_paragraph(0, 'THE BOOK', page='cover'),
+            # Narrative pages: plenty of text
+            make_paragraph(1, 'x' * 200, page='ch1'),
+            make_paragraph(2, 'x' * 150, page='ch2'),
+        ]
+        builder = ChapterBuilder(
+            pages, toc, items, paragraphs, source='toc_level_1',
+            front_matter_min_chars=100)
+        chapters = builder.build()
+        self.assertEqual(2, len(chapters))
+        # The cover page paragraph must not appear in any chapter.
+        for ch in chapters:
+            for p in ch.paragraphs:
+                self.assertNotEqual('cover', p.page,
+                    'Cover page paragraph leaked into chapter content')
+
+    def test_front_matter_filter_zero_disables(self):
+        """Setting front_matter_min_chars=0 disables the filter entirely."""
+        pages = ['cover', 'ch1']
+        items = [
+            MockManifestItem('cover', 'cover.xhtml'),
+            MockManifestItem('ch1', 'chapter1.xhtml'),
+        ]
+        toc = [MockTocNode('Ch1', 'chapter1.xhtml'),
+               MockTocNode('Cover', 'cover.xhtml')]
+        paragraphs = [
+            make_paragraph(0, 'THE BOOK', page='cover'),  # short
+            make_paragraph(1, 'x' * 200, page='ch1'),
+        ]
+        builder = ChapterBuilder(
+            pages, toc, items, paragraphs, source='toc_level_1',
+            front_matter_min_chars=0)
+        chapters = builder.build()
+        # With filter disabled, cover paragraph must appear in chapter 2
+        all_pages = {p.page for ch in chapters for p in ch.paragraphs}
+        self.assertIn('cover', all_pages)
+
+    def test_front_matter_long_pages_not_excluded(self):
+        """Pages with enough text are kept even with the filter enabled."""
+        pages = ['ch1', 'ch2']
+        items = [
+            MockManifestItem('ch1', 'chapter1.xhtml'),
+            MockManifestItem('ch2', 'chapter2.xhtml'),
+        ]
+        toc = [MockTocNode('Ch1', 'chapter1.xhtml'),
+               MockTocNode('Ch2', 'chapter2.xhtml')]
+        paragraphs = [
+            make_paragraph(0, 'x' * 200, page='ch1'),  # 200 chars > 100
+            make_paragraph(1, 'x' * 150, page='ch2'),
+        ]
+        builder = ChapterBuilder(
+            pages, toc, items, paragraphs, source='toc_level_1',
+            front_matter_min_chars=100)
+        chapters = builder.build()
+        all_pages = {p.page for ch in chapters for p in ch.paragraphs}
+        self.assertIn('ch1', all_pages)
+        self.assertIn('ch2', all_pages)
 
 
 # ---------------------------------------------------------------------------
@@ -316,10 +470,11 @@ class TestTokenBudget(unittest.TestCase):
         self.assertEqual(1, len(chunks))
         self.assertEqual(200, len(chunks[0]))
 
-    def test_chunk_default_max_paragraphs_is_60(self):
-        # Backward-compatible default. New default is 60.
+    def test_chunk_default_max_paragraphs(self):
+        # Default is deliberately conservative (20) to ensure high tag
+        # compliance on local medium-sized models.
         budget = TokenBudget(budget=8000)
-        self.assertEqual(60, budget.max_paragraphs)
+        self.assertEqual(20, budget.max_paragraphs)
 
     def test_chunk_with_stats_reports_reason(self):
         # 70 short paragraphs, generous token budget, cap=60.
@@ -519,9 +674,9 @@ class TestTagging(unittest.TestCase):
         ]
         tagged, indices = tag_paragraphs(paragraphs)
         self.assertEqual([1, 2, 3], indices)
-        self.assertIn('<P1>First.</P1>', tagged)
-        self.assertIn('<P2>Second.</P2>', tagged)
-        self.assertIn('<P3>Third.</P3>', tagged)
+        self.assertIn('[1]\nFirst.', tagged)
+        self.assertIn('[2]\nSecond.', tagged)
+        self.assertIn('[3]\nThird.', tagged)
 
     def test_tag_paragraphs_skips_ignored(self):
         paragraphs = [
@@ -532,42 +687,56 @@ class TestTagging(unittest.TestCase):
         tagged, indices = tag_paragraphs(paragraphs)
         # Indices count the *paragraphs list* position, not translated count.
         self.assertEqual([1, 3], indices)
-        self.assertIn('<P1>A</P1>', tagged)
-        self.assertIn('<P3>C</P3>', tagged)
-        self.assertNotIn('<P2>', tagged)
+        self.assertIn('[1]\nA', tagged)
+        self.assertIn('[3]\nC', tagged)
+        self.assertNotIn('[2]', tagged)
 
     def test_parse_tagged_response(self):
         response = (
             "Sure, here is the translation:\n"
-            "<P1>Primo.</P1>\n"
-            "<P2>Secondo.</P2>\n"
-            "<P3>Terzo.</P3>\nEnd of translation.")
+            "[1]\nPrimo.\n\n"
+            "[2]\nSecondo.\n\n"
+            "[3]\nTerzo.\n\nEnd of translation.")
         parsed = parse_tagged_response(response, [1, 2, 3])
         self.assertEqual({1: 'Primo.', 2: 'Secondo.', 3: 'Terzo.'}, parsed)
 
     def test_parse_tagged_response_multiline(self):
         response = (
-            "<P1>Line one.\nLine two.</P1>\n"
-            "<P2>Alone.</P2>")
+            "[1]\nLine one.\nLine two.\n\n"
+            "[2]\nAlone.")
         parsed = parse_tagged_response(response, [1, 2])
         self.assertEqual(2, len(parsed))
         self.assertIn('Line one.', parsed[1])
         self.assertIn('Line two.', parsed[1])
+        self.assertEqual('Alone.', parsed[2])
 
     def test_parse_tagged_response_missing(self):
-        response = "<P1>Only one.</P1>"
+        response = "[1]\nOnly one."
         parsed = parse_tagged_response(response, [1, 2, 3])
         self.assertEqual({1: 'Only one.'}, parsed)
 
     def test_parse_tagged_response_ignores_hallucinated_tags(self):
-        response = "<P1>Real.</P1><P5>Hallucinated.</P5>"
+        response = "[1]\nReal.\n\n[5]\nHallucinated."
         parsed = parse_tagged_response(response, [1, 2])
-        # Tag 5 was not expected; ignored.
+        # Marker 5 was not expected; ignored.
         self.assertEqual({1: 'Real.'}, parsed)
 
     def test_parse_tagged_response_empty(self):
         self.assertEqual({}, parse_tagged_response('', [1]))
         self.assertEqual({}, parse_tagged_response(None, [1]))
+
+    def test_parse_tagged_response_extra_whitespace(self):
+        response = (
+            "\n\n  [1]  \nPrimo paragrafo.\n\n\n"
+            "  [2]\nSecondo.\n")
+        parsed = parse_tagged_response(response, [1, 2])
+        self.assertEqual('Primo paragrafo.', parsed[1])
+        self.assertEqual('Secondo.', parsed[2])
+
+    def test_parse_tagged_response_duplicate_marker_last_wins(self):
+        response = "[1]\nFirst try.\n\n[1]\nBetter version."
+        parsed = parse_tagged_response(response, [1])
+        self.assertEqual('Better version.', parsed[1])
 
 
 # ---------------------------------------------------------------------------
@@ -675,6 +844,47 @@ class TestNovelCacheId(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
+def _echo_markers(text, suffix=' (IT)'):
+    """Test helper: echo back the [N] markers found in ``text``, appending
+    ``suffix`` to each paragraph body. Simulates a well-behaved LLM that
+    respects the numbered-marker translation format.
+    """
+    import re
+    result = []
+    for m in re.finditer(
+            r'^\s*\[(\d+)\]\s*\n(.*?)(?=\n\s*\[\d+\]|\Z)',
+            text, re.MULTILINE | re.DOTALL):
+        result.append('[%s]\n%s%s' % (
+            m.group(1), m.group(2).strip(), suffix))
+    return '\n\n'.join(result)
+
+
+def _is_translation_call(prompt):
+    """The novel translator uses distinct system prompts for the three
+    call kinds:
+
+      * Translation: "You are a professional literary translator..."
+      * Summary:     "You are a helpful assistant that produces concise
+                     summaries."
+      * Glossary:    "You are a helpful assistant. Answer with strict
+                     JSON only."
+
+    We detect the translation call by the presence of "translator" in the
+    prompt (unique to that path); the two "helpful assistant" prompts are
+    used for the two auxiliary calls.
+    """
+    return 'translator' in (prompt or '').lower()
+
+
+def _is_glossary_call(prompt):
+    return 'json' in (prompt or '').lower()
+
+
+def _is_summary_call(prompt):
+    return ('helpful assistant' in (prompt or '').lower()
+            and 'json' not in (prompt or '').lower())
+
+
 class FakeEngine:
     """Minimal engine stub compatible with NovelTranslator expectations."""
 
@@ -744,25 +954,12 @@ class TestNovelTranslator(unittest.TestCase):
 
     def test_run_translates_all_chapters(self):
         def side_effect(text, prompt):
-            # Translation call: response contains the same tags.
-            if '<P1>' in text or '<P2>' in text or '<P3>' in text:
-                # Echo back all tags found in the user text.
-                import re
-                result = []
-                for m in re.finditer(r'<P(\d+)>(.*?)</P\1>',
-                                     text, re.DOTALL):
-                    result.append('<P%s>%s (IT)</P%s>' % (
-                        m.group(1), m.group(2), m.group(1)))
-                return '\n'.join(result)
-            # Summary and glossary calls: return trivial values.
-            if 'Summarize' in prompt or 'summar' in prompt.lower():
-                return 'Summary text.'
-            if 'JSON' in prompt or 'entities' in prompt.lower():
+            if _is_translation_call(prompt):
+                return _echo_markers(text)
+            if _is_glossary_call(prompt):
                 return '{"entities": []}'
-            # Fallback (used e.g. by summary user-side prompt).
-            if 'summary' in text.lower():
-                return 'Summary text.'
-            return '{"entities": []}'
+            # Summary path.
+            return 'Summary text.'
         engine = FakeEngine(translate_side_effect=side_effect)
         translator = self._make_translator(engine)
         count = translator.run()
@@ -783,13 +980,8 @@ class TestNovelTranslator(unittest.TestCase):
 
         def side_effect(text, prompt):
             collected.append(text[:20])
-            if '<P' in text:
-                import re
-                return '\n'.join(
-                    '<P%s>%s (IT)</P%s>' % (m.group(1), m.group(2),
-                                             m.group(1))
-                    for m in re.finditer(r'<P(\d+)>(.*?)</P\1>',
-                                         text, re.DOTALL))
+            if _is_translation_call(prompt):
+                return _echo_markers(text)
             return '{"entities": []}'
         engine = FakeEngine(translate_side_effect=side_effect)
         translator = self._make_translator(engine)
@@ -808,11 +1000,11 @@ class TestNovelTranslator(unittest.TestCase):
             translator.run()
 
     def test_missing_tags_are_logged(self):
-        # Engine that returns only tag 1 -> alignment retries kick in but
-        # still miss tag 2.
+        # Engine that returns only marker 1 -> alignment retries kick in
+        # but still miss marker 2.
         def side_effect(text, prompt):
-            if '<P' in text:
-                return '<P1>Only first.</P1>'
+            if _is_translation_call(prompt):
+                return '[1]\nOnly first.'
             return '{"entities": []}'
         engine = FakeEngine(translate_side_effect=side_effect)
         translator = self._make_translator(engine)
@@ -822,7 +1014,7 @@ class TestNovelTranslator(unittest.TestCase):
         # The paragraph that was translated is stored, the missing one is
         # left as None but progress still advances (soft failure).
         self.assertEqual('Only first.', self.paragraphs[0].translation)
-        # Missing-tag warning was logged at some point.
+        # Missing-marker warning was logged at some point.
         warning_seen = any(
             'missing' in (c.args[0] if c.args else '').lower()
             for c in log.call_args_list)
@@ -830,15 +1022,9 @@ class TestNovelTranslator(unittest.TestCase):
 
     def test_summary_and_glossary_persisted(self):
         def side_effect(text, prompt):
-            if '<P' in text and 'JSON' not in prompt \
-                    and 'entities' not in prompt.lower():
-                import re
-                return '\n'.join(
-                    '<P%s>%s (IT)</P%s>' % (m.group(1), m.group(2),
-                                             m.group(1))
-                    for m in re.finditer(r'<P(\d+)>(.*?)</P\1>',
-                                         text, re.DOTALL))
-            if 'JSON' in prompt or 'entities' in prompt.lower():
+            if _is_translation_call(prompt):
+                return _echo_markers(text)
+            if _is_glossary_call(prompt):
                 return ('Here is JSON: {"entities": ['
                         '{"source": "Alpha", "translation": "Alfa", '
                         '"type": "character"}]}')
@@ -860,13 +1046,8 @@ class TestNovelTranslator(unittest.TestCase):
             make_paragraph(0, '', page='a', ignored=True)])
 
         def side_effect(text, prompt):
-            if '<P' in text:
-                import re
-                return '\n'.join(
-                    '<P%s>%s (IT)</P%s>' % (m.group(1), m.group(2),
-                                             m.group(1))
-                    for m in re.finditer(r'<P(\d+)>(.*?)</P\1>',
-                                         text, re.DOTALL))
+            if _is_translation_call(prompt):
+                return _echo_markers(text)
             return '{"entities": []}'
         engine = FakeEngine(translate_side_effect=side_effect)
         translator = self._make_translator(engine)
@@ -880,15 +1061,9 @@ class TestNovelTranslator(unittest.TestCase):
         tracker = {'summary': 0, 'glossary': 0}
 
         def side_effect(text, prompt):
-            if '<P' in text and 'JSON' not in prompt \
-                    and 'entities' not in prompt.lower():
-                import re
-                return '\n'.join(
-                    '<P%s>%s (IT)</P%s>' % (m.group(1), m.group(2),
-                                             m.group(1))
-                    for m in re.finditer(r'<P(\d+)>(.*?)</P\1>',
-                                         text, re.DOTALL))
-            if 'JSON' in prompt or 'entities' in prompt.lower():
+            if _is_translation_call(prompt):
+                return _echo_markers(text)
+            if _is_glossary_call(prompt):
                 tracker['glossary'] += 1
                 return '{"entities": []}'
             # Assume any other call is the summary request.
@@ -922,15 +1097,9 @@ class TestNovelTranslator(unittest.TestCase):
         ]
 
         def side_effect(text, prompt):
-            if '<P' in text and 'JSON' not in prompt \
-                    and 'entities' not in prompt.lower():
-                import re
-                return '\n'.join(
-                    '<P%s>%s (IT)</P%s>' % (m.group(1), m.group(2),
-                                             m.group(1))
-                    for m in re.finditer(r'<P(\d+)>(.*?)</P\1>',
-                                         text, re.DOTALL))
-            if 'JSON' in prompt or 'entities' in prompt.lower():
+            if _is_translation_call(prompt):
+                return _echo_markers(text)
+            if _is_glossary_call(prompt):
                 # Return plain prose, not JSON.
                 return (
                     'Here are the entities I found:\n'
@@ -946,6 +1115,31 @@ class TestNovelTranslator(unittest.TestCase):
         # At least one entity should have been recovered via the fallback.
         self.assertGreater(len(glossary), 0)
 
+    def test_head_and_tail_short_text_unchanged(self):
+        # Short text under the budget is returned verbatim.
+        engine = FakeEngine()
+        translator = self._make_translator(engine)
+        text = 'This is short.'
+        self.assertEqual(text, translator._head_and_tail(text, 100))
+
+    def test_head_and_tail_long_text_truncated(self):
+        engine = FakeEngine()
+        translator = self._make_translator(engine)
+        text = 'HEAD_START' + ('x' * 5000) + 'TAIL_END'
+        clipped = translator._head_and_tail(text, 500)
+        self.assertLess(len(clipped), len(text))
+        self.assertEqual(len(clipped), 500)
+        self.assertIn('HEAD_START', clipped)
+        self.assertNotIn('TAIL_END', clipped)
+        self.assertNotIn('middle omitted', clipped)
+
+    def test_head_and_tail_zero_disables(self):
+        # max_chars <= 0 disables truncation.
+        engine = FakeEngine()
+        translator = self._make_translator(engine)
+        text = 'x' * 100000
+        self.assertEqual(text, translator._head_and_tail(text, 0))
+
     def test_translation_failure_after_retries(self):
         engine = FakeEngine(
             translate_side_effect=lambda t, p: Exception('boom'))
@@ -953,6 +1147,137 @@ class TestNovelTranslator(unittest.TestCase):
         with patch(f'{module_name}.time'):
             with self.assertRaises(TranslationFailed):
                 translator.run()
+
+    # -- overlap chunking -------------------------------------------------
+
+    def test_overlap_default_is_three(self):
+        # Default from configuration is 3 sliding paragraphs.
+        engine = FakeEngine()
+        translator = self._make_translator(engine, config={})
+        # _make_translator forces novel_min_chars_for_context=0 but not
+        # the overlap; it should fall back to the runtime default.
+        self.assertEqual(3, translator.overlap_paragraphs)
+
+    def test_overlap_can_be_disabled(self):
+        engine = FakeEngine()
+        translator = self._make_translator(
+            engine, config={'novel_overlap_paragraphs': 0})
+        self.assertEqual(0, translator.overlap_paragraphs)
+
+    def test_overlap_negative_clamped_to_zero(self):
+        engine = FakeEngine()
+        translator = self._make_translator(
+            engine, config={'novel_overlap_paragraphs': -5})
+        self.assertEqual(0, translator.overlap_paragraphs)
+
+    def test_overlap_passed_to_next_chunk(self):
+        """When overlap > 0, the second chunk must receive as context the
+        translations produced by the first chunk."""
+        # Build a chapter with enough paragraphs to force 2 chunks
+        # (max_paragraphs=3 forces 3+3 = 2 chunks).
+        paras = [make_paragraph(i, 'para %d' % i, page='a')
+                 for i in range(6)]
+        self.chapters = [Chapter(1, 'Ch', ['a'], paras)]
+        self.paragraphs = paras
+
+        seen_users = []
+
+        def side_effect(text, prompt):
+            if _is_translation_call(prompt):
+                seen_users.append(text)
+                return _echo_markers(text)
+            if _is_glossary_call(prompt):
+                return '{"entities": []}'
+            return 'Summary.'
+
+        engine = FakeEngine(translate_side_effect=side_effect)
+        translator = self._make_translator(
+            engine, config={
+                'novel_overlap_paragraphs': 2,
+                'novel_max_paragraphs_per_chunk': 3,
+            })
+        translator.run()
+
+        # We expect at least 2 translation calls (2 chunks).
+        translation_calls = [t for t in seen_users
+                             if 'Translate each numbered' in t]
+        self.assertGreaterEqual(len(translation_calls), 2)
+        # First chunk: no overlap block.
+        first = translation_calls[0]
+        self.assertNotIn('already translated', first)
+        # Second chunk: overlap block present with previous translations.
+        second = translation_calls[1]
+        self.assertIn('already translated', second)
+        # The overlap must contain the translated form of at least one
+        # paragraph from the first chunk (which was echoed with '(IT)').
+        self.assertIn('(IT)', second.split(
+            'Translate each numbered')[0])
+
+    def test_overlap_disabled_no_context_block(self):
+        """With overlap=0 no chunk should carry a context block, even the
+        second one."""
+        paras = [make_paragraph(i, 'para %d' % i, page='a')
+                 for i in range(6)]
+        self.chapters = [Chapter(1, 'Ch', ['a'], paras)]
+        self.paragraphs = paras
+
+        seen_users = []
+
+        def side_effect(text, prompt):
+            if _is_translation_call(prompt):
+                seen_users.append(text)
+                return _echo_markers(text)
+            if _is_glossary_call(prompt):
+                return '{"entities": []}'
+            return 'Summary.'
+
+        engine = FakeEngine(translate_side_effect=side_effect)
+        translator = self._make_translator(
+            engine, config={
+                'novel_overlap_paragraphs': 0,
+                'novel_max_paragraphs_per_chunk': 3,
+            })
+        translator.run()
+
+        for t in seen_users:
+            self.assertNotIn('already translated', t)
+
+    def test_overlap_larger_than_previous_chunk_is_truncated(self):
+        """If overlap window is larger than the number of translations
+        available from the previous chunk, we simply use what we have."""
+        paras = [make_paragraph(i, 'para %d' % i, page='a')
+                 for i in range(4)]
+        self.chapters = [Chapter(1, 'Ch', ['a'], paras)]
+        self.paragraphs = paras
+
+        seen_users = []
+
+        def side_effect(text, prompt):
+            if _is_translation_call(prompt):
+                seen_users.append(text)
+                return _echo_markers(text)
+            if _is_glossary_call(prompt):
+                return '{"entities": []}'
+            return 'Summary.'
+
+        engine = FakeEngine(translate_side_effect=side_effect)
+        # Ask for 10 paragraphs of overlap but each chunk only has 2.
+        translator = self._make_translator(
+            engine, config={
+                'novel_overlap_paragraphs': 10,
+                'novel_max_paragraphs_per_chunk': 2,
+            })
+        translator.run()
+
+        # The run must complete without error, and the second chunk must
+        # still include a context block (with just 2 paragraphs, not 10).
+        translation_calls = [t for t in seen_users
+                             if 'Translate each numbered' in t]
+        self.assertGreaterEqual(len(translation_calls), 2)
+        # Every paragraph must have been translated.
+        for p in paras:
+            self.assertIsNotNone(p.translation)
+            self.assertIn('(IT)', p.translation)
 
     @patch(f'{module_name}.time')
     def test_retry_sleeps_between_attempts(self, mock_time):
@@ -963,6 +1288,425 @@ class TestNovelTranslator(unittest.TestCase):
         with self.assertRaises(TranslationFailed):
             translator._translate_with_retry('sys', 'user', attempts=2)
         mock_time.sleep.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# Structured output (JSON) path
+# ---------------------------------------------------------------------------
+
+
+class StructuredEngine(FakeEngine):
+    """FakeEngine that pretends to support structured JSON output.
+
+    Overrides ``translate`` so it *invokes* ``get_body`` (or the swapped
+    ``get_body_for_structured``) exactly once per call, giving tests a
+    reliable hook to assert which path was chosen.
+    """
+    structured_output_mode = 'schema'
+
+    def __init__(self, translate_side_effect=None):
+        super().__init__(translate_side_effect=translate_side_effect)
+        self.body_calls = []
+        self.structured_body_calls = []
+
+    def get_body(self, text):
+        self.body_calls.append(text)
+        return '{"messages": ["marker-path"]}'
+
+    def get_body_for_structured(self, text, schema=None):
+        self.structured_body_calls.append({
+            'text': text, 'schema': schema})
+        return '{"structured": true, "text": "..."}'
+
+    def translate(self, text):
+        # Force the routing hook to actually run: build the body via
+        # whatever get_body is currently swapped in on the instance,
+        # then let the parent class dispatch the response.
+        self.get_body(text)
+        return super().translate(text)
+
+
+class UnstructuredEngine(FakeEngine):
+    """FakeEngine that does NOT advertise structured output support."""
+    structured_output_mode = None
+
+
+def _echo_markers_as_json(text, suffix=' (IT)'):
+    """Test helper: parse the JSON payload embedded in ``text`` (produced
+    by ``_build_structured_payload``) and echo it back with translated
+    fields, simulating a well-behaved server returning JSON.
+    """
+    import json as _json
+    import re
+    # The payload is embedded after "Input:\n" in the user text.
+    m = re.search(r'Input:\s*\n(\{.*\})\s*\Z', text, re.DOTALL)
+    if not m:
+        return '{"paragraphs": []}'
+    try:
+        obj = _json.loads(m.group(1))
+    except ValueError:
+        return '{"paragraphs": []}'
+    out = {'paragraphs': []}
+    for p in obj.get('paragraphs', []):
+        out['paragraphs'].append({
+            'n': p['n'],
+            'translation': (p.get('source') or '').strip() + suffix,
+        })
+    return _json.dumps(out, ensure_ascii=False)
+
+
+class TestStructuredOutputCapability(unittest.TestCase):
+    """Detection of engine structured-output capability + user setting."""
+
+    def _make_translator(self, engine, config=None):
+        cache = Mock()
+        cache.get_info.return_value = None
+        ctx = ContextManager(cache).load()
+        cache.reset_mock()
+        translator = NovelTranslator(
+            engine, [], ctx, cache, config=config or {})
+        translator.set_logging(Mock())
+        translator.set_progress(Mock())
+        return translator
+
+    def test_structured_setting_default_is_auto(self):
+        translator = self._make_translator(StructuredEngine())
+        self.assertEqual('auto', translator.structured_output_setting)
+
+    def test_structured_setting_normalises_invalid_value(self):
+        translator = self._make_translator(
+            StructuredEngine(),
+            config={'novel_structured_output': 'nonsense'})
+        self.assertEqual('auto', translator.structured_output_setting)
+
+    def test_engine_supports_structured_detection_true(self):
+        translator = self._make_translator(StructuredEngine())
+        self.assertTrue(translator._engine_supports_structured())
+
+    def test_engine_supports_structured_detection_false(self):
+        translator = self._make_translator(UnstructuredEngine())
+        self.assertFalse(translator._engine_supports_structured())
+
+    def test_structured_active_auto_capable_engine(self):
+        translator = self._make_translator(StructuredEngine())
+        self.assertTrue(translator._structured_active())
+
+    def test_structured_active_auto_uncapable_engine(self):
+        translator = self._make_translator(UnstructuredEngine())
+        self.assertFalse(translator._structured_active())
+
+    def test_structured_active_off_overrides_capability(self):
+        translator = self._make_translator(
+            StructuredEngine(),
+            config={'novel_structured_output': 'off'})
+        self.assertFalse(translator._structured_active())
+
+    def test_structured_active_force_overrides_missing_capability(self):
+        translator = self._make_translator(
+            UnstructuredEngine(),
+            config={'novel_structured_output': 'force'})
+        self.assertTrue(translator._structured_active())
+
+    def test_structured_choice_logged_once(self):
+        # The verbose one-shot log should fire exactly once per instance.
+        engine = StructuredEngine()
+        translator = self._make_translator(engine)
+        log = Mock()
+        translator.set_logging(log)
+        translator._structured_active()
+        translator._structured_active()
+        translator._structured_active()
+        format_logs = [
+            c for c in log.call_args_list
+            if 'Output format' in (c.args[0] if c.args else '')]
+        self.assertEqual(1, len(format_logs))
+        self.assertIn('structured JSON', format_logs[0].args[0])
+
+    def test_structured_choice_logs_reason_when_disabled(self):
+        translator = self._make_translator(
+            StructuredEngine(),
+            config={'novel_structured_output': 'off'})
+        log = Mock()
+        translator.set_logging(log)
+        translator._structured_active()
+        format_logs = [
+            c for c in log.call_args_list
+            if 'Output format' in (c.args[0] if c.args else '')]
+        self.assertEqual(1, len(format_logs))
+        message = format_logs[0].args[0]
+        self.assertIn('text markers', message)
+        self.assertIn('disabled by user setting', message)
+
+
+class TestStructuredOutputParser(unittest.TestCase):
+    """Robustness of _parse_structured_response."""
+
+    def _make_translator(self):
+        cache = Mock()
+        cache.get_info.return_value = None
+        ctx = ContextManager(cache).load()
+        cache.reset_mock()
+        translator = NovelTranslator(
+            StructuredEngine(), [], ctx, cache, config={})
+        translator.set_logging(Mock())
+        translator.set_progress(Mock())
+        return translator
+
+    def test_parse_basic(self):
+        translator = self._make_translator()
+        response = ('{"paragraphs": ['
+                    '{"n": 1, "translation": "Primo."},'
+                    '{"n": 2, "translation": "Secondo."}]}')
+        parsed = translator._parse_structured_response(response, [1, 2])
+        self.assertEqual({1: 'Primo.', 2: 'Secondo.'}, parsed)
+
+    def test_parse_ignores_extra_fields(self):
+        translator = self._make_translator()
+        response = ('{"paragraphs": ['
+                    '{"n": 1, "translation": "Primo.", '
+                    '"source": "orig", "extra": "junk"}]}')
+        parsed = translator._parse_structured_response(response, [1])
+        self.assertEqual({1: 'Primo.'}, parsed)
+
+    def test_parse_filters_unexpected_indices(self):
+        translator = self._make_translator()
+        response = ('{"paragraphs": ['
+                    '{"n": 1, "translation": "Real."},'
+                    '{"n": 99, "translation": "Hallucinated."}]}')
+        parsed = translator._parse_structured_response(response, [1, 2])
+        self.assertEqual({1: 'Real.'}, parsed)
+
+    def test_parse_missing_paragraphs(self):
+        translator = self._make_translator()
+        response = '{"paragraphs": [{"n": 1, "translation": "Only one."}]}'
+        parsed = translator._parse_structured_response(response, [1, 2, 3])
+        self.assertEqual({1: 'Only one.'}, parsed)
+
+    def test_parse_json_with_prose_prefix(self):
+        translator = self._make_translator()
+        response = ('Here is your JSON: {"paragraphs": ['
+                    '{"n": 1, "translation": "T"}]} thanks!')
+        parsed = translator._parse_structured_response(response, [1])
+        self.assertEqual({1: 'T'}, parsed)
+
+    def test_parse_json_with_markdown_fence(self):
+        translator = self._make_translator()
+        response = ('```json\n{"paragraphs": ['
+                    '{"n": 1, "translation": "T"}]}\n```')
+        parsed = translator._parse_structured_response(response, [1])
+        self.assertEqual({1: 'T'}, parsed)
+
+    def test_parse_n_as_string(self):
+        # Some models emit "n": "1" instead of "n": 1.
+        translator = self._make_translator()
+        response = '{"paragraphs": [{"n": "1", "translation": "Uno"}]}'
+        parsed = translator._parse_structured_response(response, [1])
+        self.assertEqual({1: 'Uno'}, parsed)
+
+    def test_parse_malformed_json_returns_empty(self):
+        translator = self._make_translator()
+        parsed = translator._parse_structured_response(
+            'this is not json', [1])
+        self.assertEqual({}, parsed)
+
+    def test_parse_missing_paragraphs_field_returns_empty(self):
+        translator = self._make_translator()
+        parsed = translator._parse_structured_response(
+            '{"other": "field"}', [1])
+        self.assertEqual({}, parsed)
+
+    def test_parse_empty_translation_skipped(self):
+        translator = self._make_translator()
+        response = ('{"paragraphs": ['
+                    '{"n": 1, "translation": ""},'
+                    '{"n": 2, "translation": "OK"}]}')
+        parsed = translator._parse_structured_response(response, [1, 2])
+        # Empty translation is dropped; the alignment retry will fill it.
+        self.assertEqual({2: 'OK'}, parsed)
+
+    def test_parse_preserves_inline_placeholders(self):
+        # {id_00001} placeholders must survive the JSON round-trip.
+        translator = self._make_translator()
+        response = ('{"paragraphs": [{"n": 1, '
+                    '"translation": "Testo con {id_00001} preservato."}]}')
+        parsed = translator._parse_structured_response(response, [1])
+        self.assertIn('{id_00001}', parsed[1])
+
+
+class TestStructuredDispatcher(unittest.TestCase):
+    """The dispatcher routes to the structured path when active."""
+
+    def _make_pair(self, engine_cls, config=None):
+        cache = Mock()
+        cache.get_info.return_value = None
+        ctx = ContextManager(cache).load()
+        cache.reset_mock()
+        base_config = {'novel_min_chars_for_context': 0}
+        if config:
+            base_config.update(config)
+        paragraphs = [
+            make_paragraph(0, 'First paragraph.', page='a'),
+            make_paragraph(1, 'Second paragraph.', page='a'),
+        ]
+        chapter = Chapter(1, 'C1', ['a'], paragraphs)
+
+        def side_effect(text, prompt):
+            if _is_translation_call(prompt):
+                # Both marker path and structured path arrive here.
+                # Return the appropriate format based on the request body.
+                if '"structured"' in text or 'JSON' in text.upper() \
+                        or 'Input:' in text:
+                    return _echo_markers_as_json(text)
+                return _echo_markers(text)
+            if _is_glossary_call(prompt):
+                return '{"entities": []}'
+            return 'Summary.'
+
+        engine = engine_cls(translate_side_effect=side_effect)
+        translator = NovelTranslator(
+            engine, [chapter], ctx, cache, config=base_config)
+        translator.set_logging(Mock())
+        translator.set_progress(Mock())
+        return translator, engine, paragraphs
+
+    def test_dispatcher_calls_structured_path_when_engine_supports(self):
+        translator, engine, paragraphs = self._make_pair(StructuredEngine)
+        translator.run()
+        # get_body_for_structured must have been called at least once.
+        self.assertGreater(len(engine.structured_body_calls), 0)
+        # All paragraphs must be translated.
+        for p in paragraphs:
+            self.assertIsNotNone(p.translation)
+            self.assertIn('(IT)', p.translation)
+
+    def test_dispatcher_uses_markers_when_engine_not_capable(self):
+        translator, engine, paragraphs = self._make_pair(UnstructuredEngine)
+        translator.run()
+        # UnstructuredEngine does not override get_body_for_structured;
+        # it inherits FakeEngine (which doesn't track structured calls).
+        for p in paragraphs:
+            self.assertIsNotNone(p.translation)
+            self.assertIn('(IT)', p.translation)
+
+    def test_dispatcher_respects_off_setting(self):
+        translator, engine, paragraphs = self._make_pair(
+            StructuredEngine,
+            config={'novel_structured_output': 'off'})
+        translator.run()
+        # Engine supports structured but user forced it off: no structured
+        # calls should have been made.
+        self.assertEqual(0, len(engine.structured_body_calls))
+
+    def test_dispatcher_respects_force_setting(self):
+        # UnstructuredEngine doesn't declare capability, but 'force'
+        # asks the pipeline to try structured anyway. Since
+        # UnstructuredEngine's get_body_for_structured falls back to
+        # get_body (via GenAI default), the call still succeeds.
+        translator, engine, paragraphs = self._make_pair(
+            UnstructuredEngine,
+            config={'novel_structured_output': 'force'})
+        # Sanity: the structured path is chosen.
+        self.assertTrue(translator._structured_active())
+
+
+class TestStructuredEnginePayloads(unittest.TestCase):
+    """Verify each engine builds the correct provider-specific body.
+
+    These tests exercise the real engine classes and therefore need the
+    ``calibre_plugins.ebook_translator`` package to be importable. They
+    are skipped in isolated dev environments (where only ``lib/novel.py``
+    is loaded standalone) but run normally under ``calibre-debug``.
+    """
+
+    @classmethod
+    def _can_import_engines(cls):
+        try:
+            import calibre_plugins.ebook_translator.engines.openai  # noqa
+            import calibre_plugins.ebook_translator.engines.google  # noqa
+            return True
+        except ImportError:
+            return False
+
+    def setUp(self):
+        if not self._can_import_engines():
+            self.skipTest(
+                'engines module not importable in isolated environment')
+
+    def test_openai_response_format_json_schema(self):
+        # Import lazily to avoid loading engine chain at module scope.
+        from calibre_plugins.ebook_translator.engines.openai import (
+            ChatgptTranslate)
+        engine = ChatgptTranslate.__new__(ChatgptTranslate)
+        engine.model = 'gpt-x'
+        engine.prompt = 'You translate.'
+        engine.stream = True  # must still be disabled in structured mode
+        engine.samplings = ['temperature']
+        engine.sampling = 'temperature'
+        engine.temperature = 0.5
+        engine.top_p = 1.0
+        engine.source_lang = 'English'
+        engine.target_lang = 'Italian'
+        # Minimal method stubs needed by get_body_for_structured.
+        engine.get_prompt = lambda: 'You translate.'
+
+        schema = {'type': 'object', 'properties': {'x': {'type': 'string'}}}
+        body_str = engine.get_body_for_structured('hello', schema=schema)
+        import json as _json
+        body = _json.loads(body_str)
+        self.assertEqual('json_schema', body['response_format']['type'])
+        self.assertEqual(
+            'novel_translation',
+            body['response_format']['json_schema']['name'])
+        self.assertEqual(
+            schema, body['response_format']['json_schema']['schema'])
+        self.assertTrue(
+            body['response_format']['json_schema'].get('strict'))
+        # Streaming is disabled for structured requests.
+        self.assertNotIn('stream', body)
+
+    def test_openai_response_format_json_object_when_no_schema(self):
+        from calibre_plugins.ebook_translator.engines.openai import (
+            ChatgptTranslate)
+        engine = ChatgptTranslate.__new__(ChatgptTranslate)
+        engine.model = 'gpt-x'
+        engine.prompt = 'You translate.'
+        engine.stream = False
+        engine.samplings = ['temperature']
+        engine.sampling = 'temperature'
+        engine.temperature = 0.5
+        engine.top_p = 1.0
+        engine.source_lang = 'English'
+        engine.target_lang = 'Italian'
+        engine.get_prompt = lambda: 'You translate.'
+
+        body_str = engine.get_body_for_structured('hi', schema=None)
+        import json as _json
+        body = _json.loads(body_str)
+        self.assertEqual('json_object', body['response_format']['type'])
+
+    def test_gemini_response_mime_and_schema(self):
+        from calibre_plugins.ebook_translator.engines.google import (
+            GeminiTranslate)
+        engine = GeminiTranslate.__new__(GeminiTranslate)
+        engine.model = 'gemini-x'
+        engine.stream = False
+        engine.temperature = 0.5
+        engine.top_p = 1.0
+        engine.top_k = 40
+        engine.source_lang = 'English'
+        engine.target_lang = 'Italian'
+        # Minimal method stubs used by GeminiTranslate.get_body().
+        engine._prompt = lambda text: 'Translate: ' + text
+
+        schema = {'type': 'object', 'properties': {'x': {'type': 'string'}}}
+        body_str = engine.get_body_for_structured('hi', schema=schema)
+        import json as _json
+        body = _json.loads(body_str)
+        self.assertEqual(
+            'application/json',
+            body['generationConfig']['responseMimeType'])
+        self.assertEqual(
+            schema, body['generationConfig']['responseSchema'])
 
 
 if __name__ == '__main__':

--- a/tests/lib/test_novel.py
+++ b/tests/lib/test_novel.py
@@ -282,6 +282,85 @@ class TestTokenBudget(unittest.TestCase):
         # All paragraphs (including ignored) are still present.
         self.assertEqual(3, len(chunks[0]))
 
+    # -- dual-cap chunking ------------------------------------------------
+
+    def test_chunk_capped_by_max_paragraphs(self):
+        # 100 very short paragraphs, small token weight but many tags.
+        # Cap tokens is generous (8000) so the paragraph cap should fire.
+        paragraphs = [make_paragraph(i, 'short') for i in range(100)]
+        budget = TokenBudget(budget=8000, max_paragraphs=30)
+        chunks = budget.chunk(paragraphs, reserved=0)
+        # 100 / 30 = ceil(3.33) => 4 chunks.
+        self.assertEqual(4, len(chunks))
+        for c in chunks:
+            # Each chunk must not exceed the paragraph cap.
+            self.assertLessEqual(len(c), 30)
+
+    def test_chunk_capped_by_tokens(self):
+        # Few very large paragraphs: token cap should fire first.
+        paragraphs = [make_paragraph(i, 'x' * 3000) for i in range(5)]
+        # Very small token budget forces splitting on tokens.
+        budget = TokenBudget(budget=200, max_paragraphs=60)
+        chunks = budget.chunk(paragraphs, reserved=0)
+        # Oversized paragraphs become singleton chunks -> 5 chunks.
+        self.assertGreater(len(chunks), 1)
+        # No chunk should hold more than one paragraph in this case.
+        for c in chunks:
+            self.assertEqual(1, len(c))
+
+    def test_chunk_max_paragraphs_zero_disables_cap(self):
+        # Many short paragraphs, generous token budget, cap=0 -> single chunk.
+        paragraphs = [make_paragraph(i, 'short') for i in range(200)]
+        budget = TokenBudget(budget=100000, max_paragraphs=0)
+        chunks = budget.chunk(paragraphs, reserved=0)
+        self.assertEqual(1, len(chunks))
+        self.assertEqual(200, len(chunks[0]))
+
+    def test_chunk_default_max_paragraphs_is_60(self):
+        # Backward-compatible default. New default is 60.
+        budget = TokenBudget(budget=8000)
+        self.assertEqual(60, budget.max_paragraphs)
+
+    def test_chunk_with_stats_reports_reason(self):
+        # 70 short paragraphs, generous token budget, cap=60.
+        # First chunk closed by paragraphs, second by end of stream.
+        paragraphs = [make_paragraph(i, 'short') for i in range(70)]
+        budget = TokenBudget(budget=100000, max_paragraphs=60)
+        stats = budget.chunk_with_stats(paragraphs, reserved=0)
+        self.assertEqual(2, len(stats))
+        # (chunk, tokens, reason)
+        self.assertEqual(TokenBudget.REASON_PARAGRAPHS, stats[0][2])
+        self.assertEqual(TokenBudget.REASON_END, stats[-1][2])
+        # First chunk has exactly 60 paragraphs (the cap).
+        self.assertEqual(60, len(stats[0][0]))
+
+    def test_chunk_with_stats_token_reason(self):
+        # Trigger token-based closure with small budget.
+        paragraphs = [make_paragraph(i, 'x' * 400) for i in range(10)]
+        # 400 chars / 4 ~= 100 tokens per paragraph.
+        budget = TokenBudget(budget=250, max_paragraphs=60)
+        stats = budget.chunk_with_stats(paragraphs, reserved=0)
+        # At least the first split should be token-driven.
+        reasons = [s[2] for s in stats[:-1]]
+        self.assertIn(TokenBudget.REASON_TOKENS, reasons)
+
+    def test_chunk_ignored_do_not_count_toward_paragraph_cap(self):
+        # 5 translatable + 55 ignored + 5 translatable = 10 translatable
+        # but 65 total. With max_paragraphs=60 the cap should NOT fire
+        # because ignored paragraphs do not consume the budget.
+        paragraphs = []
+        for i in range(5):
+            paragraphs.append(make_paragraph(i, 'text'))
+        for i in range(5, 60):
+            paragraphs.append(make_paragraph(i, '', ignored=True))
+        for i in range(60, 65):
+            paragraphs.append(make_paragraph(i, 'text'))
+        budget = TokenBudget(budget=100000, max_paragraphs=60)
+        chunks = budget.chunk(paragraphs, reserved=0)
+        # All 65 paragraphs (including ignored) fit in a single chunk.
+        self.assertEqual(1, len(chunks))
+        self.assertEqual(65, len(chunks[0]))
+
 
 # ---------------------------------------------------------------------------
 # ContextManager

--- a/tests/lib/test_utils.py
+++ b/tests/lib/test_utils.py
@@ -1,4 +1,5 @@
 import unittest
+import socket
 from unittest.mock import patch
 from types import GeneratorType
 
@@ -8,7 +9,7 @@ from ...vendor.cssselect import SelectorError
 
 from ...lib.utils import (
     ns, css, css_to_xpath, create_xpath, uid, trim, chunk, group, open_file,
-    request)
+    request, keepalive_socket, _KeepAliveSocket, original_socket)
 
 
 module_name = 'calibre_plugins.ebook_translator.lib.utils'
@@ -198,3 +199,64 @@ class TestUtils(unittest.TestCase):
             'https://example.com/api', 'test data',
             headers={'User-Agent': 'Test/Agent'}, timeout=30, method='POST')
         browser.open.assert_called_once_with(mock_request())
+
+
+class TestKeepAliveSocket(unittest.TestCase):
+    """Tests for the TCP keepalive helper used by novel-mode structured
+    output (see lib/novel.py::_translate_with_retry_structured)."""
+
+    def test_class_is_a_socket_subclass(self):
+        # _KeepAliveSocket must be usable as a drop-in replacement for
+        # socket.socket wherever a factory is expected.
+        self.assertTrue(issubclass(_KeepAliveSocket, socket.socket))
+
+    def test_can_be_instantiated(self):
+        # Instantiation must not fail (does not open a real connection).
+        s = _KeepAliveSocket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            self.assertGreater(s.fileno(), 0)
+        finally:
+            s.close()
+
+    def test_keepalive_socket_swaps_and_restores(self):
+        # Context manager must swap socket.socket while inside the block
+        # and put the original one back on exit.
+        before = socket.socket
+        try:
+            with keepalive_socket(enable=True):
+                self.assertIs(socket.socket, _KeepAliveSocket)
+            self.assertIs(socket.socket, before)
+        finally:
+            # Safety net: force restore in case the test fails midway so
+            # we do not pollute subsequent tests.
+            socket.socket = before
+
+    def test_keepalive_socket_disabled_is_noop(self):
+        before = socket.socket
+        with keepalive_socket(enable=False):
+            self.assertIs(socket.socket, before)
+        self.assertIs(socket.socket, before)
+
+    def test_keepalive_socket_restores_on_exception(self):
+        before = socket.socket
+        with self.assertRaises(RuntimeError):
+            with keepalive_socket(enable=True):
+                self.assertIs(socket.socket, _KeepAliveSocket)
+                raise RuntimeError('boom')
+        self.assertIs(socket.socket, before)
+
+    def test_keepalive_socket_skips_when_already_patched(self):
+        # If someone else (e.g. socks_proxy) has already patched
+        # socket.socket, we must NOT overwrite their patch.
+        class _AlreadyPatched(socket.socket):
+            pass
+
+        before = socket.socket
+        socket.socket = _AlreadyPatched
+        try:
+            with keepalive_socket(enable=True):
+                # Our wrapper must have detected the existing patch and
+                # left socket.socket untouched.
+                self.assertIs(socket.socket, _AlreadyPatched)
+        finally:
+            socket.socket = before

--- a/ui.py
+++ b/ui.py
@@ -18,6 +18,7 @@ from .cache import CacheManager
 from .about import AboutDialog
 from .components import AlertMessage, ModeSelection
 from .advanced import CreateTranslationProject, AdvancedTranslation
+from .novel import CreateNovelProject, NovelTranslation
 
 
 load_translations()  # type: ignore
@@ -48,6 +49,7 @@ class EbookTranslatorGui(InterfaceAction):
         menu.addAction(
             _('Advanced Mode'), self.show_advanced_translation)
         menu.addAction(_('Batch Mode'), self.show_batch_translation)
+        menu.addAction(_('Novel Mode'), self.show_novel_translation)
         menu.addSeparator()
         menu.addAction(_('Cache'), self.show_cache)
         menu.addSeparator()
@@ -106,6 +108,36 @@ class EbookTranslatorGui(InterfaceAction):
         window.show()
         self.add_window('batch', window)
 
+    def novel_translation_window(self, ebook):
+        name = 'novel_' + uid(ebook.get_input_path())
+        if self.show_window(name):
+            return
+        worker = ConversionWorker(self.gui, self.icon)
+        window = NovelTranslation(self, self.gui, worker, ebook)
+        window.setMinimumWidth(1000)
+        window.setMinimumHeight(640)
+        window.setWindowTitle(
+            '%s - %s' % (_('Novel Mode'), self.title))
+        window.setWindowIcon(self.icon)
+        window.show()
+        self.add_window(name, window)
+
+    def show_novel_translation(self):
+        ebooks = self.get_selected_ebooks()
+        if len(ebooks) < 1:
+            return self.alert.pop(
+                _('Please choose a book.'), 'warning')
+        if len(ebooks) > 1:
+            return self.alert.pop(
+                _('Novel Mode supports one book at a time. '
+                  'Please select a single book.'), 'warning')
+        window = CreateNovelProject(self.gui, ebooks.first())
+        window.start_translation.connect(self.novel_translation_window)
+        window.setModal(True)
+        window.setWindowTitle(
+            '%s - %s' % (_('Novel Mode'), self.title))
+        window.show()
+
     def show_setting(self):
         if self.has_running_jobs():
             self.alert.pop(_(
@@ -155,14 +187,15 @@ class EbookTranslatorGui(InterfaceAction):
         modes = {
             'advanced': self.show_advanced_translation,
             'batch': self.show_batch_translation,
+            'novel': self.show_novel_translation,
         }
         preferred_mode = get_config().get('preferred_mode')
         if not preferred_mode:
             window = ModeSelection(self.gui)
             window.choose_action.connect(self.select_preferred_mode)
             window.setModal(True)
-            window.setMaximumWidth(500)
-            window.setMaximumHeight(200)
+            window.setMaximumWidth(700)
+            window.setMaximumHeight(220)
             window.setWindowTitle(
                 '%s - %s' % (_('Choose Translation Mode'), self.title))
             window.show()
@@ -207,7 +240,7 @@ class EbookTranslatorGui(InterfaceAction):
             return True
         windows = self.gui.bookfere_ebook_translator.windows
         for name in windows:
-            if name.startswith('advanced_'):
+            if name.startswith('advanced_') or name.startswith('novel_'):
                 return True
         return False
 


### PR DESCRIPTION
# feat: Novel Mode — Context-Aware LLM Translation Pipeline

## Overview

This PR introduces **Novel Mode**, a dedicated translation pipeline for LLMs that
translates narrative long-form content (novels, anthologies) with persistent
context across the entire book. Unlike the existing paragraph-by-paragraph
pipeline, Novel Mode works chapter by chapter, maintaining a running summary
and a dynamic glossary of characters, places, and objects that are injected
into every subsequent request.

Novel Mode is implemented as a **third, fully independent mode** alongside the
existing Advanced and Batch modes. All existing functionality is unaffected.

---

## Motivation

The default pipeline sends one request per paragraph (or a small merge of
paragraphs). For LLM engines this produces:

- **Inconsistent character names and pronouns** across paragraph boundaries
- **No awareness of previous plot events**, forcing the model to guess context
- **Style drift** — the model picks a register in paragraph 1 that drifts by paragraph 500
- **No shared terminology** — the same named entity is translated differently each time

Novel Mode solves these by keeping the LLM informed of what has already
happened in the book and what all the named entities are called.

---

## New Files

| File | Description |
|---|---|
| `lib/novel.py` | Core pipeline: `Chapter`, `ChapterBuilder`, `TokenBudget`, `ContextManager`, `NovelTranslator` |
| `novel.py` | Qt UI dialog (`NovelTranslation`) with chapter list, progress bar, Summary / Glossary / Log tabs |
| `build_plugin.sh` | Shell script to build the installable `.zip` |
| `tests/lib/test_novel.py` | 117 unit tests covering all novel-mode components |

---

## Modified Files

### `lib/novel.py` — Core pipeline

#### `ChapterBuilder`

Builds `Chapter` objects from the OEB manifest and TOC.

- **`source='toc_level_1'`** (default): uses top-level TOC entries as chapter
  boundaries. Suitable for single-book EPUBs.
- **`source='toc_level_2'`** (new): uses second-level TOC entries (sub-chapters).
  Recommended for multi-book anthologies (e.g. a complete series in one EPUB)
  where level-1 entries map to entire novels. Falls back to level-1 when
  level-2 has fewer than two entries.
- **`front_matter_min_chars=100`** (new): pages whose total text is shorter than
  this threshold are silently excluded from chapter content. Prevents Cover and
  Titlepage pages from appearing as the first paragraph of a translation chunk,
  which causes hallucinations when the model sees a title in ALL-CAPS with no
  narrative context.

#### `TokenBudget` — dual-cap chunking

Closes a chunk when **either** limit is reached first:

- `budget` (token cap, default 12 000): prevents overflowing the model context window.
- `max_paragraphs` (paragraph cap, default 80): prevents the LLM from losing track
  of `[N]` alignment markers when paragraphs are short (dialogue, TOC lists).

Returns `chunk_with_stats()` tuples `(chunk, tokens_estimate, reason)` so the
caller can log which cap fired.

#### `ContextManager`

Persists summaries and the glossary to the SQLite translation cache (`info`
key-value table — no schema change). Supports:

- `append_chapter(index, title, summary, glossary_delta)` — accumulates context
- `context_text(budget_tokens)` — returns a formatted string with priority-based
  truncation (glossary > recent summaries > older summaries)
- `reset()` — clears all context (UI "Reset context" button)

#### `NovelTranslator` — sequential orchestrator

Translates chapters one by one (no concurrency). For each chapter:

1. Chunks the translatable paragraphs with `TokenBudget` dual-cap.
2. Builds a system prompt with the running summary and dynamic glossary.
3. Translates each chunk, retrying alignment on missing markers (up to 2 retries).
4. Passes the last N translated paragraphs as **sliding-window overlap** to the
   next chunk (analogous to RAG chunking), preserving dialogue threads and
   pronoun referents across chunk boundaries.
5. Generates a chapter summary via a dedicated LLM call.
6. Extracts new named entities (characters, places, objects) and merges them
   into the cumulative glossary.
7. Persists progress to cache after every chapter, enabling **resume** from any
   interruption point.

---

### Paragraph alignment format

Paragraphs are tagged with numeric markers `[N]\ntext` instead of XML tags
`<Pn>...</Pn>`. Local LLMs (Gemma, Mistral, LLaMA) follow this format far more
reliably because it matches the numbered-list patterns in their training data.
XML-balanced tags require closing tags that models tend to drop when context
is long.

---

### Structured output (native JSON)

When the engine advertises `structured_output_mode = 'schema'` (ChatGPT,
Gemini, Ollama via OpenAI-compatible endpoint), the pipeline switches to
native JSON enforcement:

- `get_body_for_structured(text, schema)` added to `ChatgptTranslate` and
  `GeminiTranslate`: injects `response_format: {type: json_schema}` (or
  `json_object`) into the request body.
- `stream: true` is kept enabled so the SSE stream prevents NAT / firewall
  idle-timeout disconnections during the long prefill phase.
- `reasoning_effort: none` is set in both `get_body()` and
  `get_body_for_structured()` to disable chain-of-thought reasoning tokens on
  Ollama 0.31+ models (Gemma 4) — without this, each request generates
  thousands of silent reasoning tokens before any translation output, making
  requests appear stalled.

User-configurable via `novel_structured_output`: `auto` (default) | `off` | `force`.

With structured output enabled the paragraph cap can safely be raised from 20
to 60+ without alignment errors.

---

### TCP keepalive for long-running remote connections

`lib/utils.py` adds:

- `_KeepAliveSocket`: a `socket.socket` subclass that enables
  `SO_KEEPALIVE + TCP_KEEPIDLE=10s + TCP_KEEPINTVL=5s + TCP_KEEPCNT=3`
  immediately after `connect()`.
- `keepalive_socket(enable)`: context manager that temporarily monkey-patches
  `socket.socket` with the keepalive subclass (same pattern as the existing
  `socks_proxy` context manager). Detects if a foreign patch is already active
  and degrades gracefully to a no-op.
- `request(keepalive=False)`: new optional parameter, default `False`.
  Wraps `br.open()` inside `with keepalive_socket(enable=keepalive)`.

`Base.translate()` forwards `keepalive=getattr(self, 'request_keepalive', False)`
to `request()`. `NovelTranslator._translate_with_retry_structured()` sets
`translator.request_keepalive = True` for the duration of each structured
call (restored in `finally`), preventing NAT routers from dropping the
connection during the prefill silent period (typically 30–90 s for a 5 000-token
prompt on a local GPU).

---

### `lib/element.py` — structural link preservation in `only` mode

**`_has_structural_links()`** and **`_clone_with_translation()`** (new methods on
`PageElement`): when `position='only'`, instead of building a flat text
replacement, deep-clone the original element and replace only the leaf text
nodes while preserving all child elements and their attributes (`href`, `id`,
`name`). This ensures that in-page TOC links and navigation anchors survive
translation in "With no original" mode.

**Bug fix — tail duplication** (`lib/element.py:355`): for elements structured
as `<li><a href="...">Chapter One</a>: The Wrong Door</li>`, the tail text
`": The Wrong Door"` was preserved verbatim after the translation, producing
output like `"Capitolo Uno: La porta sbagliata: The Wrong Door"`. Fixed by
setting the tail to `None` when the fallback generates an empty part instead
of `(elem.tail or '')`.

---

### `lib/utils.py` — TCP keepalive helpers

See "TCP keepalive" section above.

---

### `engines/genai.py`

- `structured_output_mode: str | None = None` — class attribute; subclasses opt in.
- `supports_novel_mode: bool = True` — marker consumed by the UI to grey out
  Novel Mode for non-LLM engines.
- `override_prompt(text)` / `restore_prompt()` — transient system-prompt swap
  used by the novel pipeline to inject context-aware prompts without permanently
  mutating the engine configuration.
- `get_body_for_structured(text, schema=None)` — default fallback that delegates
  to `get_body(text)` so non-overriding engines silently continue on the marker path.

### `engines/openai.py`

- `structured_output_mode = 'schema'`
- `get_body_for_structured()`: injects `response_format` (json_schema or
  json_object) and `stream: true`; sets `reasoning_effort: none`.
- `get_body()`: adds `reasoning_effort: none` to every request (not just
  structured) to suppress Gemma 4 chain-of-thought reasoning on Ollama 0.31+.

### `engines/google.py` (GeminiTranslate)

- `structured_output_mode = 'schema'`
- `get_body_for_structured()`: adds `responseMimeType: application/json` and
  optional `responseSchema` to `generationConfig`.

### `engines/base.py`

- `translate()`: forwards `keepalive=getattr(self, 'request_keepalive', False)`
  to `request()`.
- `supports_novel_mode: bool = False` — default for all non-GenAI engines.

---

### `lib/conversion.py`

- `get_novel_config()`: single source of truth for the novel-mode configuration
  dict, used by both the interactive UI worker and the background job entry point
  (`convert_item_novel`). Prevents configuration drift between the two code paths
  (the root cause of a bug where UI-configured values like `max_paragraphs_per_chunk`
  were silently ignored).
- `convert_item_novel()`: dedicated entry point for the novel-mode Calibre job
  (`arbitrary_n`). Kept separate from `convert_item()` to avoid the
  `"multiple values for argument 'notification'"` error caused by Calibre's job
  runner injecting `notification` as the last positional argument.
- `convert_book_novel()`: novel-mode variant of `convert_book()` with
  `cache_only` fast-path for "Build translated ebook" (reuses cache, skips LLM).

---

### `lib/config.py`

New configuration keys (all with sensible defaults):

| Key | Default | Description |
|---|---|---|
| `novel_chunk_tokens` | `12000` | Max estimated tokens per chunk |
| `novel_max_paragraphs_per_chunk` | `80` | Paragraph cap (dual-cap with tokens) |
| `novel_overlap_paragraphs` | `3` | Sliding-window overlap between chunks |
| `novel_structured_output` | `'auto'` | JSON structured output: auto / off / force |
| `novel_front_matter_min_chars` | `100` | Pages shorter than this are skipped as front matter |
| `novel_context_tokens` | `1500` | Token budget for summary + glossary in system prompt |
| `novel_summary_tokens` | `400` | Target length of chapter summary |
| `novel_glossary_max_entries` | `200` | Hard cap on glossary size (FIFO eviction) |
| `novel_min_chars_for_context` | `300` | Skip summary/glossary for chapters shorter than this |
| `novel_chapter_source` | `'toc_level_1'` | Chapter detection strategy |

---

### `novel.py` — Qt UI

`NovelTranslation(QDialog)` with:

- **Chapter list sidebar** with per-chapter status icons (●pending / ▶running / ✓done / ✗error).
- **Progress bar** updated after each chapter.
- **Summaries tab**: running LLM-generated summaries, one per completed chapter.
- **Glossary tab**: editable table of named entities (source / translation / type / notes).
  Updated incrementally via signal payload — no SQLite read-back race condition.
- **Log tab**: streaming engine log with error highlighting.
- **Start / Resume** button: automatically resumes from the last completed chapter.
- **Reset context**: discards summaries and glossary, resets chapter progress.
- **Build translated ebook**: launches a Calibre background job to produce the
  final EPUB/format from the populated cache (no LLM calls).

`CreateNovelProject(QDialog)`: initial setup dialog (format, source/target language).
Warns if the selected engine does not support novel mode.

---

### `setting.py`

New **Novel Mode** section in the Engine tab (visible only for GenAI engines):

| Setting | Description |
|---|---|
| Chapter detection | TOC level 1 / TOC level 2 / One XHTML file |
| Skip front matter under (chars) | Exclude decorative pages |
| Max tokens per chunk | Token budget per LLM call |
| Max paragraphs per chunk | Paragraph cap (dual-cap) |
| Overlap paragraphs | Sliding-window overlap |
| Structured output | Auto / Off / Force |
| Skip context under (chars) | Skip summary/glossary for short chapters |
| Glossary max entries | Cap on dynamic glossary size |
| Chunk size (tokens) for summary | Budget for summary/glossary LLM calls |

**Preferred Mode** radio button group extended with **Novel Mode**.

---

### `components/mode.py`

`ModeSelection` dialog extended with a third column: **Novel Mode** description and Choose button.

---

### `ui.py`

- `Novel Mode` entry added to the plugin toolbar menu.
- `show_novel_translation()`: validates single-book selection, opens `CreateNovelProject`.
- `novel_translation_window()`: manages the `NovelTranslation` window lifecycle.
- `has_running_jobs()`: extended to detect active novel translation windows.
- `select_preferred_mode()`: extended to handle `preferred_mode = 'novel'`.

---

## Testing

117 unit tests across three test files:

- `tests/lib/test_novel.py` — `ChapterBuilder` (TOC level 1/2, front-matter
  filter), `TokenBudget` (dual-cap, `chunk_with_stats`), `ContextManager`
  (persist / load / truncation / glossary cap), `NovelTranslator` (full pipeline,
  resume, cancellation, overlap, structured output dispatcher), parser and tagger
  functions.
- `tests/lib/test_element.py` — structural link preservation in `only` mode,
  tail-duplication regression.
- `tests/lib/test_utils.py` — `_KeepAliveSocket` instantiation, `keepalive_socket`
  swap/restore, interaction with existing patches.

All tests pass. The three engine payload tests (`TestStructuredEnginePayloads`)
require the full `calibre_plugins` package and are skipped in the isolated
development environment; they run correctly under `calibre-debug`.

---

## Compatibility

- **Zero breaking changes** to Advanced Mode and Batch Mode.
- **Retro-compatible configuration**: all new keys have defaults; existing
  installations need no migration.
- **Engine compatibility**: Novel Mode is available only for GenAI engines
  (`ChatgptTranslate`, `ClaudeTranslate`, `GeminiTranslate`, and any
  OpenAI-compatible custom endpoint including Ollama). Free translation
  engines (Google, DeepL, …) are unaffected.
- **Ollama support**: works out of the box via the existing ChatGPT engine with
  a custom endpoint (`http://localhost:11434/v1/chat/completions`). Tested with
  Gemma 4 26B Q4_K_M on AMD RX 7900 XTX (ROCm).

---

## Usage

1. Select a single book in the Calibre library.
2. Click the plugin toolbar button → **Novel Mode**.
3. Choose source/target language and click **Start**.
4. Monitor translation progress in the Novel Mode window.
5. When all chapters are complete, click **Build translated ebook**.

To resume after an interruption: open Novel Mode on the same book — the
**Start / Resume** button picks up from the last completed chapter.