### PR TITLE
fix(cache): preserve small completed translation caches

### DIFF
--- a/lib/cache.py
+++ b/lib/cache.py
@@ -121,10 +121,7 @@ class TranslationCache:
         self.identity = identity
         self.persistence = persistence
         self.file_path = self._path(identity)
-        # An interruption may occur, resulting in the cache size being less
-        # than 50,000 bytes. Therefore, we need to resave it again.
-        if os.path.exists(self.file_path) and self.size() > 50000:
-            self.fresh = False
+        cache_existed = os.path.exists(self.file_path)
         self.cache_only = False
         self.connection = sqlite3.connect(
             self.file_path, check_same_thread=False)
@@ -137,6 +134,9 @@ class TranslationCache:
             'target_lang DEFAULT NULL)')
         self.cursor.execute(
             'CREATE TABLE IF NOT EXISTS info(key UNIQUE, value)')
+        paragraph_count = self.cursor.execute(
+            'SELECT COUNT(*) FROM cache').fetchone()[0]
+        self.fresh = not cache_existed or paragraph_count == 0
 
     @classmethod
     def move(cls, dest):

--- a/tests/lib/test_cache.py
+++ b/tests/lib/test_cache.py
@@ -1,6 +1,8 @@
+import os
 import unittest
+from tempfile import TemporaryDirectory
 
-from ...lib.cache import Paragraph
+from ...lib.cache import Paragraph, TranslationCache
 
 
 class TestParagraph(unittest.TestCase):
@@ -75,3 +77,47 @@ class TestParagraph(unittest.TestCase):
         self.paragraph.translation = 'A\n\nB\nC'
         self.paragraph.do_aligment('\n\n')
         self.assertEqual('A\n\nB\n\nC', self.paragraph.translation)
+
+
+class TestTranslationCacheRecovery(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = TemporaryDirectory()
+        self.original_paths = (
+            TranslationCache.dir_path,
+            TranslationCache.cache_path,
+            TranslationCache.temp_path,
+        )
+        TranslationCache.dir_path = self.temp_dir.name
+        TranslationCache.cache_path = os.path.join(
+            self.temp_dir.name, 'cache')
+        TranslationCache.temp_path = os.path.join(
+            self.temp_dir.name, 'temp')
+
+    def tearDown(self):
+        (
+            TranslationCache.dir_path,
+            TranslationCache.cache_path,
+            TranslationCache.temp_path,
+        ) = self.original_paths
+        self.temp_dir.cleanup()
+
+    def test_reopens_small_cache_with_completed_translation(self):
+        cache = TranslationCache('small-book')
+        cache.save([(
+            1, 'paragraph-md5', '<p>Hello</p>', 'Hello', False, None,
+            'chapter.xhtml')])
+        paragraph = cache.paragraph(1)
+        paragraph.translation = '你好'
+        paragraph.engine_name = 'Primary'
+        paragraph.target_lang = 'Chinese'
+        cache.update_paragraph(paragraph)
+        cache_path = cache.file_path
+        cache.close()
+
+        self.assertLess(os.path.getsize(cache_path), 50000)
+        reopened = TranslationCache('small-book')
+        try:
+            self.assertFalse(reopened.is_fresh())
+            self.assertEqual('你好', reopened.paragraph(1).translation)
+        finally:
+            reopened.close()


### PR DESCRIPTION
## Summary

- replace the cache file-size heuristic with a content-based freshness check
- preserve completed translations stored in small SQLite cache files
- add a regression test covering cache files below the previous 50 KB threshold

## Background

`TranslationCache` previously treated an existing database as reusable only when its file size exceeded 50,000 bytes. That heuristic was intended to detect interrupted writes, but it also classified valid caches for short books or partially completed jobs as fresh. When the project was reopened, the plugin could discard the recovered state and require translation to start again.

The cache is now considered reusable when the database already exists and contains paragraph records. Empty or newly created databases remain fresh.

## User impact

Completed translations in small cache databases are restored correctly after the dialog is closed, Calibre restarts, or a translation session is interrupted.

## Validation

- verified the regression test fails against the previous implementation
- verified the regression test passes with this change
- ran the complete Calibre plugin test suite: **251 tests passed**
- ran `git diff --check`

## Risk

Low. The change is limited to cache freshness detection and does not modify the database schema or stored data.
