### PR TITLE
fix(settings): avoid blocking errors during automatic model discovery

### DIFF
--- a/setting.py
+++ b/setting.py
@@ -28,6 +28,19 @@ from .components import (
 load_translations()  # type: ignore
 
 
+class ModelFetchState:
+    def __init__(self):
+        self.manual = False
+
+    def begin(self, manual=False):
+        self.manual = manual
+
+    def finish(self, success):
+        show_error = not success and self.manual
+        self.manual = False
+        return show_error
+
+
 class ModelWorker(QObject):
     start = pyqtSignal(object)
     success = pyqtSignal(bool, str)
@@ -90,6 +103,7 @@ class TranslationSetting(QDialog):
         self.plugin = plugin
         self.icon = icon
         self.alert = AlertMessage(self)
+        self.model_fetch_state = ModelFetchState()
 
         self.config = get_config()
         self.current_engine = get_engine_class()
@@ -607,7 +621,7 @@ class TranslationSetting(QDialog):
             lambda model: self.current_engine.config.update(
                 model=model.strip()))
 
-        def fetch_ai_models():
+        def fetch_ai_models(manual=False):
             try:
                 genai_model_list.currentTextChanged.disconnect()
             except TypeError:
@@ -618,11 +632,12 @@ class TranslationSetting(QDialog):
             genai_model_list.setDisabled(True)
             genai_model_input.setVisible(False)
             self.current_engine.set_config(self.get_engine_config())
+            self.model_fetch_state.begin(manual)
             self.model_worker.start.emit(self.current_engine)
 
         def manual_fetch_ai_models():
             if self.api_keys.toPlainText().strip() != '':
-                fetch_ai_models()
+                fetch_ai_models(manual=True)
             else:
                 self.alert.pop(_('You need to provide an API key to proceed.'))
         genai_model_refresh.clicked.connect(manual_fetch_ai_models)
@@ -639,7 +654,7 @@ class TranslationSetting(QDialog):
 
         def handle_worker_status(success, message=''):
             genai_model_refresh.setVisible(not success)
-            if not success:
+            if self.model_fetch_state.finish(success):
                 error_dialog(self, _("Can't fetch model list"), _(
                     "Can't fetch model list, please check and try again."),
                     message, show=True)

--- a/tests/test_model_fetch_state.py
+++ b/tests/test_model_fetch_state.py
@@ -1,0 +1,25 @@
+import unittest
+
+from ..setting import ModelFetchState
+
+
+class TestModelFetchState(unittest.TestCase):
+    def test_automatic_failure_does_not_request_dialog(self):
+        state = ModelFetchState()
+        state.begin(manual=False)
+
+        self.assertFalse(state.finish(success=False))
+
+    def test_manual_failure_requests_dialog(self):
+        state = ModelFetchState()
+        state.begin(manual=True)
+
+        self.assertTrue(state.finish(success=False))
+
+    def test_completion_resets_manual_request_state(self):
+        state = ModelFetchState()
+        state.begin(manual=True)
+        self.assertFalse(state.finish(success=True))
+        state.begin(manual=False)
+
+        self.assertFalse(state.finish(success=False))


### PR DESCRIPTION
## Summary

- distinguish automatic model discovery from an explicit user refresh
- suppress modal error dialogs when background model discovery fails
- preserve detailed error reporting when the user clicks **Refresh**
- add focused tests for automatic, manual, and reset behavior

## Background

OpenAI-compatible and self-hosted endpoints do not always implement the `/v1/models` endpoint. Some valid configurations therefore return `404 Not Found` during automatic model discovery even though the configured chat-completions endpoint works correctly.

The existing settings flow displays a modal "Can't fetch model list" error for every discovery failure. This makes opening or switching an otherwise usable custom engine unnecessarily disruptive.

This change tracks whether model discovery was initiated automatically or manually. Automatic failures remain logged by `ModelWorker`, expose the existing refresh control, and avoid interrupting the user. A manual refresh still presents the full error dialog so configuration problems can be diagnosed on demand.

## User impact

Users can configure custom or self-hosted models without receiving a blocking error solely because model enumeration is unsupported. Explicit refresh attempts retain the current diagnostic behavior.

## Validation

- added tests for automatic failure, manual failure, and state reset after completion
- ran the focused model-fetch state tests: **3 tests passed**
- ran the complete Calibre plugin test suite: **253 tests passed**
- ran `git diff --check`

## Risk

Low. Request execution and model parsing are unchanged. The patch only controls whether an existing error dialog is shown based on the origin of the fetch request.

Related to #580.
