### PR TITLE
fix(srt): write translated subtitles as UTF-8

### DIFF
--- a/lib/conversion.py
+++ b/lib/conversion.py
@@ -106,7 +106,7 @@ def convert_srt(
     log.info(_('Starting to output subtitles file...'))
     log.info(sep())
 
-    with open(output_path, 'w') as file:
+    with open(output_path, 'w', encoding='utf-8') as file:
         file.write('\n\n'.join([e.get_translation() for e in elements]))
 
     log.info(_('The translation of the subtitles file was completed.'))


### PR DESCRIPTION
## Problem

`convert_srt()` opens the output file without specifying an encoding:

```python
with open(output_path, 'w') as file:
```

This falls back to the platform default encoding (`locale.getpreferredencoding()`), which is a non-UTF-8 code page on Windows (e.g. cp936 for Simplified Chinese, cp1252 for Western Europe). Translating a subtitle file into a non-ASCII target language then either raises `UnicodeEncodeError` or silently writes mojibake.

## Root cause & fix

`convert_pgn()` in the same module already writes its output with `encoding='utf-8'`. The SRT convertor simply missed it. This PR makes them consistent — a one-line change:

```diff
-    with open(output_path, 'w') as file:
+    with open(output_path, 'w', encoding='utf-8') as file:
```

## Impact

Fixes subtitle (`.srt`) translation on Windows (and any non-UTF-8 locale) for non-Latin target languages.

## Notes

- Scope is intentionally minimal (single line).
- The convert pipeline depends on Calibre, so this was not executed against a live Calibre instance; the change mirrors the existing, working `convert_pgn()` behaviour in the same file.
- I did not find an existing open issue tracking this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)