### PR TITLE
fix(element): preserve numbers when condensing repeated characters

### DIFF
--- a/lib/element.py
+++ b/lib/element.py
@@ -240,8 +240,10 @@ class PageElement(Element):
 
     def _polish_translation(self, translation):
         translation = translation.replace('\n', '<br/>')
-        # Condense consecutive letters to a maximum of four.
-        return re.sub(r'((\w)\2{3})\2*', r'\1', translation)
+        # Condense a run of the same letter down to four (some engines emit
+        # repetition artifacts). Digits and underscores are excluded so that
+        # legitimate content such as "100000000" is not silently corrupted.
+        return re.sub(r'(([^\W\d_])\2{3})\2*', r'\1', translation)
 
     def _create_new_element(
             self, name, content='', copy_attrs=True, excluding_attrs=[]):


### PR DESCRIPTION
## Problem

`PageElement._polish_translation()` runs on **every** translated page element:

```python
# Condense consecutive letters to a maximum of four.
return re.sub(r'((\w)\2{3})\2*', r'\1', translation)
```

The intent is to smooth over repetition artifacts (some engines occasionally emit runs like `aaaaaa`). But `\w` also matches **digits**, so any legitimate number with 4+ repeated digits is silently rewritten:

| input | old output |
|---|---|
| `总奖金为 100000000 美元` | `总奖金为 10000 美元` |
| `The value is 5555555` | `The value is 5555` |
| `编号 A0000000123` | `编号 A0000123` |

This is silent data corruption with no log message, and it affects all engines — even Google/DeepL, which don't produce repetition artifacts in the first place.

## Fix

Restrict the character class to letters (`[^\W\d_]`), leaving digits and underscores untouched. The letter/CJK collapsing behaviour is unchanged:

```diff
-        return re.sub(r'((\w)\2{3})\2*', r'\1', translation)
+        return re.sub(r'(([^\W\d_])\2{3})\2*', r'\1', translation)
```

## Verification

Standalone comparison of the old vs. new regex:

```
INPUT                     | OLD               | NEW
--------------------------------------------------------------
总奖金为 100000000 美元    | 总奖金为 10000 美元 | 总奖金为 100000000 美元
The value is 5555555      | The value is 5555 | The value is 5555555
编号 A0000000123          | 编号 A0000123     | 编号 A0000000123
wooooooow                 | woooow            | woooow            (unchanged)
Loooooong ago             | Loooong ago       | Loooong ago       (unchanged)
哈哈哈哈哈哈哈             | 哈哈哈哈           | 哈哈哈哈           (unchanged)
```

Digits are preserved; the repetition-collapsing behaviour for letters and CJK is identical to before.

## Notes

- Minimal scope: one line (plus a clarified comment).
- `element.py` imports Calibre, so only the regex was verified standalone (above), not the full module.
- I did not find an existing open issue tracking this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)