### PR TITLE
fix(engines): tolerate SSE lines without a space after "data:"

### DIFF
--- a/engines/anthropic.py
+++ b/engines/anthropic.py
@@ -152,7 +152,7 @@ class ClaudeTranslate(GenAI):
                     .format(str(e)))
 
             if line.startswith('data:'):
-                chunk: dict = json.loads(line.split('data: ')[1])
+                chunk: dict = json.loads(line.split('data:', 1)[1].strip())
                 event_type: str = chunk['type']
 
                 if event_type not in self.valid_event_types:

--- a/engines/google.py
+++ b/engines/google.py
@@ -446,7 +446,7 @@ class GeminiTranslate(GenAI):
                     _('Can not parse returned response. Raw data: {}')
                     .format(str(e)))
             if line.startswith('data:'):
-                item = json.loads(line.split('data: ')[1])
+                item = json.loads(line.split('data:', 1)[1].strip())
                 candidate = item['candidates'][0]
                 content = candidate['content']
                 if 'parts' in content.keys():

--- a/engines/openai.py
+++ b/engines/openai.py
@@ -149,7 +149,7 @@ class ChatgptTranslate(GenAI):
             if not line:
                 continue
             if line.startswith('data:'):
-                chunk = line.split('data: ')[1]
+                chunk = line.split('data:', 1)[1].strip()
                 if chunk == '[DONE]':
                     break
                 try:

--- a/tests/lib/test_engine.py
+++ b/tests/lib/test_engine.py
@@ -522,6 +522,22 @@ class TestChatgptTranslate(unittest.TestCase):
         self.assertIsInstance(result, GeneratorType)
         self.assertEqual('你好世界！', ''.join(result))
 
+    @patch(module_name + '.openai.EbookTranslator')
+    @patch(module_name + '.base.request')
+    def test_translate_stream_without_data_space(self, mock_request, mock_et):
+        # SSE lines may omit the space after "data:" (e.g. "data:{...}").
+        mock_et.__version__ = '1.0.0'
+        template = b'data:{"choices":[{"delta":{"content":"%b"}}]}'
+        mock_response = Mock()
+        mock_response.readline.side_effect = [
+            template % i.encode() for i in '你好世界！'] \
+            + ['data:[DONE]'.encode()]
+        mock_request.return_value = mock_response
+        result = self.translator.translate('Hello World!')
+
+        self.assertIsInstance(result, GeneratorType)
+        self.assertEqual('你好世界！', ''.join(result))
+
     @patch(module_name + '.base.request')
     def test_translate_normal(self, mock_request):
         mock_request.return_value = \
@@ -1024,6 +1040,25 @@ data: {"type":"message_stop"}
             proxy_uri=None, raw_object=True)
         self.assertIsInstance(result, GeneratorType)
         self.assertEqual('你好世界！', ''.join(result))
+
+    @patch(module_name + '.anthropic.EbookTranslator')
+    @patch(module_name + '.base.request')
+    def test_translate_stream_without_data_space(self, mock_request, mock_et):
+        # SSE lines may omit the space after "data:" (e.g. "data:{...}").
+        mock_et.__version__ = '1.0.0'
+        data_sample = (
+            'data:{"type":"content_block_delta","delta":{"text":"你"}}\n'
+            'data:{"type":"content_block_delta","delta":{"text":"好"}}\n'
+            'data:{"type":"message_stop"}\n')
+        mock_response = Mock()
+        mock_response.readline.side_effect = data_sample.encode().splitlines()
+        mock_request.return_value = mock_response
+        self.translator.endpoint = 'https://api.anthropic.com/v1/messages'
+        self.translator.model = 'claude-3-5-sonnet-20241022'
+        result = self.translator.translate('Hello World!')
+
+        self.assertIsInstance(result, GeneratorType)
+        self.assertEqual('你好', ''.join(result))
 
 
 class TestFunction(unittest.TestCase):


### PR DESCRIPTION
## Problem

The streaming (SSE) parsers in the ChatGPT/OpenAI, Claude and Gemini engines split each line on the literal `'data: '` (with a **trailing space**) and take index `[1]`:

```python
chunk = line.split('data: ')[1]                 # engines/openai.py
chunk = json.loads(line.split('data: ')[1])     # engines/anthropic.py
item  = json.loads(line.split('data: ')[1])     # engines/google.py
```

The [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation) allows a field with no space after the colon (`data:value`). Several OpenAI-compatible endpoints (local servers, gateways) emit exactly that. For such a line, `split('data: ')` returns a single-element list and `[1]` raises `IndexError`.

That `IndexError` is thrown **outside** the `try/except json.JSONDecodeError` guard, so it aborts the generator and bubbles up as a generic "translation failed" that then gets retried until it gives up — the endpoint appears completely broken to the user.

Demonstration:

```
line='data: {"a":1}'  -> '{"a":1}'      ok
line='data:{"a":1}'   -> IndexError!    (not caught)
```

## Fix

Split on `'data:'` once and strip the remainder, in all three engines:

```diff
-chunk = line.split('data: ')[1]
+chunk = line.split('data:', 1)[1].strip()
```

This handles both `data: {...}` and `data:{...}`, and the `[DONE]` sentinel check is unaffected (`data:[DONE]` and `data: [DONE]` both strip to `[DONE]`).

## Tests

Adds `test_translate_stream_without_data_space` regression tests for the OpenAI and Claude parsers (mirroring the existing `test_translate_stream`, but feeding `data:`-without-space lines).

## Verification

- Split logic verified standalone for `data: {..}`, `data:{..}`, `data: [DONE]`, `data:[DONE]` — all parse correctly, no `IndexError`.
- `py_compile` passes for the three engines and the test module (Python 3.12).
- The engine modules import Calibre, so the added unit tests were **not** run locally against Calibre; they follow the exact structure of the existing streaming tests and are meant to run in the project's Calibre-based test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)