### PR TITLE
fix(google): decode gcloud output with errors='replace'

### DIFF
--- a/engines/google.py
+++ b/engines/google.py
@@ -151,7 +151,7 @@ class GoogleTranslate(Base):
                 startupinfo.dwFlags |= STARTF_USESHOWWINDOW
             process = Popen(
                 command, stdout=PIPE, stderr=PIPE, universal_newlines=True,
-                startupinfo=startupinfo)
+                errors='replace', startupinfo=startupinfo)
         except Exception:
             if silence:
                 return None


### PR DESCRIPTION
Fixes #309.

## Problem

Reported in #309: using **Google (Basic) ADC** on a Chinese Windows 11 raises

```
File ".../engines/google.py", line ... in _get_credential
File ".../engines/google.py", line ... in _run_command
File "codecs.py", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xcf in position 96: invalid continuation byte
```

`_run_command()` launches `gcloud` and reads its output in text mode:

```python
process = Popen(
    command, stdout=PIPE, stderr=PIPE, universal_newlines=True,
    startupinfo=startupinfo)
```

On a non-English Windows console, `gcloud` prints error/diagnostic text in the local code page (e.g. GBK — `0xcf` is a GBK lead byte), while the Calibre-embedded interpreter decodes the pipe as UTF-8. The invalid byte raises `UnicodeDecodeError`, which **crashes on the decode itself and masks the real gcloud error**.

## Fix

Add `errors='replace'` so undecodable bytes degrade to `U+FFFD` instead of throwing:

```diff
 process = Popen(
     command, stdout=PIPE, stderr=PIPE, universal_newlines=True,
-    startupinfo=startupinfo)
+    errors='replace', startupinfo=startupinfo)
```

The access token on the success path is pure ASCII and is unaffected; the ASCII portion of any error message (paths, English text) stays readable.

## Verification

Reproduced the exact failure with a subprocess emitting ASCII + GBK bytes, decoded as UTF-8:

```
old (no errors handler): UnicodeDecodeError: 'utf-8' codec can't decode byte 0xcf ... invalid continuation byte
new (errors='replace'):  'access-token-abc �� done'   # no crash, ASCII preserved
```

The `0xcf ... invalid continuation byte` matches the report in #309.

## Notes

- Minimal scope: one argument.
- Verified via a standalone subprocess repro (above). Not executed inside a live Calibre instance on Windows, but the decode path and the reproduced error match the traceback in #309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)